### PR TITLE
Message callbacks

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -164,10 +164,11 @@ func buildHandler(logger log.Logger, db *dbcontext.DB, cfg *config.Config) http.
 		logger,
 	)
 
+	callbackURLs := setupCallbackUrls(cfg)
 	for id, client := range clients {
 		logger.Infof("starting client %s", id)
 		self.RunService(
-			self.NewService(client, connectionRepo, factRepo, messageRepo, logger),
+			self.NewService(client, connectionRepo, factRepo, messageRepo, callbackURLs[id], logger),
 			logger,
 		)
 	}
@@ -201,7 +202,16 @@ func setupSelfClients(cfg *config.Config) (map[string]*selfsdk.Client, error) {
 	}
 
 	return clients, nil
+}
 
+func setupCallbackUrls(cfg *config.Config) map[string]string {
+	urls := make(map[string]string, len(cfg.SelfApps))
+
+	for _, c := range cfg.SelfApps {
+		urls[c.SelfAppID] = c.CallbackURL
+	}
+
+	return urls
 }
 
 // logDBQuery returns a logging function that can be used to log SQL queries.

--- a/config/local.yml
+++ b/config/local.yml
@@ -5,6 +5,7 @@ self_apps:
     self_storage_dir: "./storage" # The storage folder you want to use for Self sessions.
     self_storage_key: "ksdh827hofuasihdjn" # Key to be used for encrypting local storage.
     self_env: "review" # Self environment you want to point to.
+    message_notification_url: "https://my-local-server/" # The URL to send incoming messages notifications to.
 jwt_signing_key: "LxsKJywDL5O5PvgODZhBH12KE6k2yL8E" # Signing key for JWT.
 user: "demo" # User to be used for JWT authentication.
 password: "pass" # Password to be used for JWT authentication.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,7 @@ type SelfAppConfig struct {
 	SelfStorageKey      string `yaml:"self_storage_key" env:"SELF_STORAGE_KEY"`
 	SelfStorageDir      string `yaml:"self_storage_dir" env:"SELF_STORAGE_DIR"`
 	SelfEnv             string `yaml:"self_env" env:"SELF_ENV"`
+	CallbackURL         string `yaml:"message_notification_url" env:"MESSAGE_NOTIFICATION_URL"`
 }
 
 // Config represents an application configuration.

--- a/internal/request/service.go
+++ b/internal/request/service.go
@@ -1,10 +1,8 @@
 package request
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
-	"net/http"
 	"time"
 
 	validation "github.com/go-ozzo/ozzo-validation/v4"
@@ -13,6 +11,7 @@ import (
 	"github.com/joinself/restful-client/internal/entity"
 	"github.com/joinself/restful-client/internal/fact"
 	"github.com/joinself/restful-client/pkg/log"
+	"github.com/joinself/restful-client/pkg/webhook"
 	selffact "github.com/joinself/self-go-sdk/fact"
 )
 
@@ -203,19 +202,9 @@ func (s service) sendCallback(appID string, req entity.Request) {
 		return
 	}
 
-	//Encode the data
-	postBody, err := json.Marshal(resp)
+	err = webhook.Post(req.Callback, resp)
 	if err != nil {
-		s.logger.Info("error marshalling request: %v", err)
-		return
-	}
-	responseBody := bytes.NewBuffer(postBody)
-
-	//Leverage Go's HTTP Post function to make request
-	_, err = http.Post(req.Callback, "application/json", responseBody)
-	if err != nil {
-		s.logger.Info("error when calling callback webhook %v", err)
-		return
+		s.logger.Info(err)
 	}
 }
 

--- a/pkg/webhook/post.go
+++ b/pkg/webhook/post.go
@@ -1,0 +1,25 @@
+package webhook
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+)
+
+func Post(url string, m interface{}) error {
+	//Encode the data
+	postBody, err := json.Marshal(m)
+	if err != nil {
+		return errors.New(fmt.Sprintf("error marshalling request: %v", err))
+	}
+	responseBody := bytes.NewBuffer(postBody)
+
+	//Leverage Go's HTTP Post function to make request
+	_, err = http.Post(url, "application/json", responseBody)
+	if err != nil {
+		return errors.New(fmt.Sprintf("error when calling callback webhook %v", err))
+	}
+	return nil
+}


### PR DESCRIPTION
### Enhancement: Webhook Callback for New Messages

This pull request adds a new feature that enables developers to receive webhook callbacks whenever a new message is received.

Callback URLs can now be defined on a per-app basis in the configuration file. If you choose not to enable this functionality, you can leave the message_notification_url field empty.

With this enhancement, whenever the server receives a new message, it will automatically trigger a POST request to the configured callback URL. The request will include the message body, just as you would receive it through the `GET /.../message/:id` endpoint.

This new functionality allows for real-time notifications and integration with external systems based on incoming messages.

Please review the changes and merge this pull request if it meets the requirements and passes all tests.
