### PR TITLE
allow customise description on fact requests

### DIFF
--- a/internal/entity/request.go
+++ b/internal/entity/request.go
@@ -19,6 +19,7 @@ type Request struct {
 	Type         string    `json:"typ"`
 	ConnectionID int       `json:"-"`
 	Facts        []byte    `json:"facts"`
+	Description  string    `json:"description"`
 	Auth         bool      `json:"auth,omitempty"`
 	Status       string    `json:"status"`
 	Callback     string    `json:"callback"`

--- a/internal/request/service.go
+++ b/internal/request/service.go
@@ -49,9 +49,10 @@ type FactRequest struct {
 
 // CreateRequest represents an request creation request.
 type CreateRequest struct {
-	Type     string        `json:"type"`
-	Facts    []FactRequest `json:"facts"`
-	Callback string        `json:"callback"`
+	Type        string        `json:"type"`
+	Facts       []FactRequest `json:"facts"`
+	Description string        `json:"description"`
+	Callback    string        `json:"callback"`
 }
 
 // Validate validates the CreateFactRequest fields.
@@ -137,6 +138,7 @@ func (s service) Create(ctx context.Context, appID, selfID string, connection in
 		Facts:        factsBody,
 		Status:       "requested",
 		Callback:     req.Callback,
+		Description:  req.Description,
 		CreatedAt:    now,
 		UpdatedAt:    now,
 	}
@@ -227,7 +229,7 @@ func (s service) buildSelfFactRequest(selfID string, req entity.Request) (*selff
 
 	r := &selffact.FactRequest{
 		SelfID:      selfID,
-		Description: "info",
+		Description: req.Description,
 		Facts:       facts,
 		Expiry:      time.Minute * 5,
 	}

--- a/migrations/20230717094013_factdescription.down.sql
+++ b/migrations/20230717094013_factdescription.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE request
+DROP COLUMN description;

--- a/migrations/20230717094013_factdescription.up.sql
+++ b/migrations/20230717094013_factdescription.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE request
+ADD COLUMN description VARCHAR(255);


### PR DESCRIPTION
Allows customising the fact request description on fact requests. 

You can customise the description by sending a fact request like to the endpoint 
`http://localhost:8080/v1/apps/{{app_id}}/connections/{{connection_self_id}}/requests`
with the body:
```json
{
  "type": "fact",
  "description": "This is my cool description",
  "facts": [{
    "name": "email_address"
  }]
}
```