### PR TITLE
Issuing facts

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -121,7 +121,7 @@ func buildHandler(logger log.Logger, db *dbcontext.DB, cfg *config.Config) http.
 
 	// Services
 	fcs := make(map[string]connection.FactService, len(clients))
-	rcs := make(map[string]fact.RequesterService, len(clients))
+	rcs := make(map[string]fact.IssuerService, len(clients))
 	rrcs := make(map[string]request.RequesterService, len(clients))
 	for id, c := range clients {
 		fcs[id] = c.FactService()

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -506,6 +506,56 @@ const docTemplate = `{
                 }
             }
         },
+        "/apps/{app_id}/connections/{connection_id}/facts": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Issues a fact to one of your connections.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "facts"
+                ],
+                "summary": "Issues a fact.",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "App id",
+                        "name": "app_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Connection id",
+                        "name": "connection_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "query params",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/fact.CreateFactRequestDoc"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        },
         "/apps/{app_id}/connections/{connection_id}/requests": {
             "post": {
                 "security": [
@@ -525,18 +575,6 @@ const docTemplate = `{
                 ],
                 "summary": "Sends a request request.",
                 "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "page number",
-                        "name": "page",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "number of elements per page",
-                        "name": "per_page",
-                        "in": "query"
-                    },
                     {
                         "type": "string",
                         "description": "App id",
@@ -819,6 +857,42 @@ const docTemplate = `{
                 }
             }
         },
+        "fact.CreateFactRequestDoc": {
+            "type": "object",
+            "properties": {
+                "facts": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "group": {
+                                "type": "object",
+                                "properties": {
+                                    "icon": {
+                                        "type": "string"
+                                    },
+                                    "name": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "key": {
+                                "type": "string"
+                            },
+                            "source": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "fact.Fact": {
             "type": "object",
             "properties": {
@@ -930,6 +1004,9 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "callback": {
+                    "type": "string"
+                },
+                "description": {
                     "type": "string"
                 },
                 "facts": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -503,6 +503,56 @@
                 }
             }
         },
+        "/apps/{app_id}/connections/{connection_id}/facts": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Issues a fact to one of your connections.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "facts"
+                ],
+                "summary": "Issues a fact.",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "App id",
+                        "name": "app_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Connection id",
+                        "name": "connection_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "query params",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/fact.CreateFactRequestDoc"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        },
         "/apps/{app_id}/connections/{connection_id}/requests": {
             "post": {
                 "security": [
@@ -522,18 +572,6 @@
                 ],
                 "summary": "Sends a request request.",
                 "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "page number",
-                        "name": "page",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "number of elements per page",
-                        "name": "per_page",
-                        "in": "query"
-                    },
                     {
                         "type": "string",
                         "description": "App id",
@@ -816,6 +854,42 @@
                 }
             }
         },
+        "fact.CreateFactRequestDoc": {
+            "type": "object",
+            "properties": {
+                "facts": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "group": {
+                                "type": "object",
+                                "properties": {
+                                    "icon": {
+                                        "type": "string"
+                                    },
+                                    "name": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "key": {
+                                "type": "string"
+                            },
+                            "source": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "fact.Fact": {
             "type": "object",
             "properties": {
@@ -927,6 +1001,9 @@
             "type": "object",
             "properties": {
                 "callback": {
+                    "type": "string"
+                },
+                "description": {
                     "type": "string"
                 },
                 "facts": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -85,6 +85,29 @@ definitions:
       value:
         type: string
     type: object
+  fact.CreateFactRequestDoc:
+    properties:
+      facts:
+        items:
+          properties:
+            group:
+              properties:
+                icon:
+                  type: string
+                name:
+                  type: string
+              type: object
+            key:
+              type: string
+            source:
+              type: string
+            type:
+              type: string
+            value:
+              type: string
+          type: object
+        type: array
+    type: object
   fact.Fact:
     properties:
       attestations:
@@ -158,6 +181,8 @@ definitions:
   request.CreateRequest:
     properties:
       callback:
+        type: string
+      description:
         type: string
       facts:
         items:
@@ -528,20 +553,44 @@ paths:
       summary: Updates a connection.
       tags:
       - connections
+  /apps/{app_id}/connections/{connection_id}/facts:
+    post:
+      consumes:
+      - application/json
+      description: Issues a fact to one of your connections.
+      parameters:
+      - description: App id
+        in: path
+        name: app_id
+        required: true
+        type: string
+      - description: Connection id
+        in: path
+        name: connection_id
+        required: true
+        type: string
+      - description: query params
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/fact.CreateFactRequestDoc'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+      security:
+      - BearerAuth: []
+      summary: Issues a fact.
+      tags:
+      - facts
   /apps/{app_id}/connections/{connection_id}/requests:
     post:
       consumes:
       - application/json
       description: Sends a request request to the specified self user.
       parameters:
-      - description: page number
-        in: query
-        name: page
-        type: integer
-      - description: number of elements per page
-        in: query
-        name: per_page
-        type: integer
       - description: App id
         in: path
         name: app_id

--- a/internal/fact/api.go
+++ b/internal/fact/api.go
@@ -15,12 +15,12 @@ func RegisterHandlers(r *echo.Group, service Service, cService connection.Servic
 
 	r.Use(authHandler)
 
-	r.GET("/apps/:app_id/connections/:connection_id/facts/:id", res.get)
 	r.GET("/apps/:app_id/connections/:connection_id/facts", res.query)
-
 	r.POST("/apps/:app_id/connections/:connection_id/facts", res.create)
-	r.PUT("/apps/:app_id/connections/:connection_id/facts/:id", res.update)
+	r.GET("/apps/:app_id/connections/:connection_id/facts/:id", res.get)
 	r.DELETE("/apps/:app_id/connections/:connection_id/facts/:id", res.delete)
+
+	// r.PUT("/apps/:app_id/connections/:connection_id/facts/:id", res.update)
 }
 
 type resource struct {
@@ -83,18 +83,19 @@ func (r resource) create(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, "")
 	}
 
+	ctx := c.Request().Context()
 	// Get the connection id
-	conn, err := r.cService.Get(c.Request().Context(), c.Param("app_id"), c.Param("connection_id"))
+	conn, err := r.cService.Get(ctx, c.Param("app_id"), c.Param("connection_id"))
 	if err != nil {
 		return c.JSON(http.StatusNotFound, err.Error())
 	}
 
-	fact, err := r.service.Create(c.Request().Context(), c.Param("app_id"), c.Param("connection_id"), conn.ID, input)
+	err = r.service.Create(ctx, c.Param("app_id"), c.Param("connection_id"), conn.ID, input)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, err.Error())
 	}
 
-	return c.JSON(http.StatusCreated, fact)
+	return c.JSON(http.StatusCreated, ``)
 }
 
 func (r resource) update(c echo.Context) error {

--- a/internal/fact/api.go
+++ b/internal/fact/api.go
@@ -76,6 +76,34 @@ func (r resource) query(c echo.Context) error {
 	return c.JSON(http.StatusOK, pages)
 }
 
+// WARNING: Do not use for code purposes, this is only used to generate
+// the documentation for the openapi, which seems to be broken for nested
+// structs.
+type CreateFactRequestDoc struct {
+	Facts []struct {
+		Key    string `json:"key"`
+		Value  string `json:"value"`
+		Source string `json:"source"`
+		Group  *struct {
+			Name string `json:"name"`
+			Icon string `json:"icon"`
+		} `json:"group,omitempty"`
+		Type string `json:"type,omitempty"`
+	} `json:"facts"`
+}
+
+// CreateConnection godoc
+// @Summary         Issues a fact.
+// @Description  	Issues a fact to one of your connections.
+// @Tags            facts
+// @Accept          json
+// @Produce         json
+// @Security        BearerAuth
+// @Param           app_id   path      string  true  "App id"
+// @Param           connection_id  path string  true  "Connection id"
+// @Param           request body CreateFactRequestDoc true "query params"
+// @Success         200
+// @Router          /apps/{app_id}/connections/{connection_id}/facts [post]
 func (r resource) create(c echo.Context) error {
 	var input CreateFactRequest
 	if err := c.Bind(&input); err != nil {

--- a/internal/fact/api_test.go
+++ b/internal/fact/api_test.go
@@ -42,17 +42,9 @@ func TestAPI(t *testing.T) {
 		{Name: "get all", Method: "GET", URL: "/apps/app1/connections/connection/facts", Body: "", Header: header, WantStatus: http.StatusOK, WantResponse: `*"total_count":1*`},
 		{Name: "get 123", Method: "GET", URL: "/apps/app1/connections/connection/facts/123", Body: "", Header: header, WantStatus: http.StatusOK, WantResponse: `*123*`},
 		{Name: "get unknown", Method: "GET", URL: "/apps/app1/connections/connection/facts/1234", Body: "", Header: header, WantStatus: http.StatusNotFound, WantResponse: ""},
-		{Name: "create ok", Method: "POST", URL: "/apps/app1/connections/connection/facts", Body: `{"fact":"test"}`, Header: header, WantStatus: http.StatusCreated, WantResponse: "*test*"},
-		{Name: "create ok count", Method: "GET", URL: "/apps/app1/connections/connection/facts", Body: "", Header: header, WantStatus: http.StatusOK, WantResponse: `*"total_count":2*`},
+		{Name: "create ok", Method: "POST", URL: "/apps/app1/connections/connection/facts", Body: `{"fact":"test"}`, Header: header, WantStatus: http.StatusCreated, WantResponse: ""},
 		{Name: "create auth error", Method: "POST", URL: "/apps/app1/connections/connection/facts", Body: `{"body":"test"}`, Header: nil, WantStatus: http.StatusUnauthorized, WantResponse: ""},
 		{Name: "create input error", Method: "POST", URL: "/apps/app1/connections/connection/facts", Body: `"body":"test"}`, Header: header, WantStatus: http.StatusBadRequest, WantResponse: ""},
-		{Name: "update ok", Method: "PUT", URL: "/apps/app1/connections/connection/facts/123", Body: `{"body":"factxyz"}`, Header: header, WantStatus: http.StatusOK, WantResponse: "*factxyz*"},
-		{Name: "update verify", Method: "GET", URL: "/apps/app1/connections/connection/facts/123", Body: "", Header: header, WantStatus: http.StatusOK, WantResponse: `*factxyz*`},
-		{Name: "update auth error", Method: "PUT", URL: "/apps/app1/connections/connection/facts/123", Body: `{"body":"factxyz"}`, Header: nil, WantStatus: http.StatusUnauthorized, WantResponse: ""},
-		{Name: "update input error", Method: "PUT", URL: "/apps/app1/connections/connection/facts/123", Body: `"body":"factxyz"}`, Header: header, WantStatus: http.StatusBadRequest, WantResponse: ""},
-		{Name: "delete ok", Method: "DELETE", URL: "/apps/app1/connections/connection/facts/123", Body: ``, Header: header, WantStatus: http.StatusOK, WantResponse: "*factxyz*"},
-		{Name: "delete verify", Method: "DELETE", URL: "/apps/app1/connections/connection/facts/123", Body: ``, Header: header, WantStatus: http.StatusNotFound, WantResponse: ""},
-		{Name: "delete auth error", Method: "DELETE", URL: "/apps/app1/connections/connection/facts/123", Body: ``, Header: nil, WantStatus: http.StatusUnauthorized, WantResponse: ""},
 	}
 	for _, tc := range tests {
 		test.Endpoint(t, router, tc)

--- a/internal/fact/service_test.go
+++ b/internal/fact/service_test.go
@@ -2,15 +2,13 @@ package fact
 
 import (
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/joinself/restful-client/pkg/log"
 	"github.com/joinself/restful-client/pkg/mock"
+	"github.com/joinself/self-go-sdk/fact"
 	"github.com/stretchr/testify/assert"
 )
-
-var errCRUD = errors.New("error crud")
 
 func TestCreateFactRequest_Validate(t *testing.T) {
 	tests := []struct {
@@ -18,9 +16,28 @@ func TestCreateFactRequest_Validate(t *testing.T) {
 		model     CreateFactRequest
 		wantError bool
 	}{
-		{"success", CreateFactRequest{Fact: "test"}, false},
-		{"required", CreateFactRequest{Fact: ""}, true},
-		{"too long", CreateFactRequest{Fact: "1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890"}, true},
+		{"success", CreateFactRequest{
+			Facts: []fact.FactToIssue{{
+				Key:   "test",
+				Value: "test",
+			}},
+		}, false},
+		{"required", CreateFactRequest{
+			Facts: []fact.FactToIssue{{
+				Key: "test",
+			}},
+		}, true},
+		{"required-key", CreateFactRequest{
+			Facts: []fact.FactToIssue{{
+				Value: "test",
+			}},
+		}, true},
+		{"too long", CreateFactRequest{
+			Facts: []fact.FactToIssue{{
+				Key:   "1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890",
+				Value: "test",
+			}},
+		}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -59,67 +76,28 @@ func Test_service_CRUD(t *testing.T) {
 	assert.Equal(t, 0, count)
 
 	// successful creation
-	fact, err := s.Create(ctx, "app", "connection", 1, CreateFactRequest{Fact: "test"})
+	err := s.Create(ctx, "app", "connection", 1, CreateFactRequest{
+		Facts: []fact.FactToIssue{{
+			Key:   "test",
+			Value: "test",
+		}},
+	})
 	assert.Nil(t, err)
-	assert.NotEmpty(t, fact.ID)
-	id := fact.ID
-	assert.Equal(t, "test", fact.Fact.Fact)
-	assert.NotEmpty(t, fact.CreatedAt)
-	assert.NotEmpty(t, fact.UpdatedAt)
-	count, _ = s.Count(ctx, 1, "", "")
-	assert.Equal(t, 1, count)
 
 	// validation error in creation
-	_, err = s.Create(ctx, "app", "connection", 1, CreateFactRequest{Fact: ""})
+	err = s.Create(ctx, "app", "connection", 1, CreateFactRequest{
+		Facts: []fact.FactToIssue{{
+			Value: "test",
+		}},
+	})
 	assert.NotNil(t, err)
-	count, _ = s.Count(ctx, 1, "", "")
-	assert.Equal(t, 1, count)
 
 	// unexpected error in creation
-	_, err = s.Create(ctx, "app", "connection", 1, CreateFactRequest{Fact: "error"})
-	assert.Equal(t, errCRUD, err)
-	count, _ = s.Count(ctx, 1, "", "")
-	assert.Equal(t, 1, count)
-
-	_, _ = s.Create(ctx, "app", "connection", 1, CreateFactRequest{Fact: "test2"})
-
-	// update
-	fact, err = s.Update(ctx, id, UpdateFactRequest{Body: "test updated"})
-	assert.Nil(t, err)
-	assert.Equal(t, "test updated", fact.Body)
-	_, err = s.Update(ctx, "none", UpdateFactRequest{Body: "test updated"})
-	assert.NotNil(t, err)
-
-	// validation error in update
-	_, err = s.Update(ctx, id, UpdateFactRequest{Body: ""})
-	assert.NotNil(t, err)
-	count, _ = s.Count(ctx, 1, "", "")
-	assert.Equal(t, 2, count)
-
-	// unexpected error in update
-	_, err = s.Update(ctx, id, UpdateFactRequest{Body: "error"})
-	assert.Equal(t, errCRUD, err)
-	count, _ = s.Count(ctx, 1, "", "")
-	assert.Equal(t, 2, count)
-
-	// get
-	_, err = s.Get(ctx, "none")
-	assert.NotNil(t, err)
-	fact, err = s.Get(ctx, id)
-	assert.Nil(t, err)
-	assert.Equal(t, "test updated", fact.Body)
-	assert.Equal(t, id, fact.ID)
-
-	// query
-	facts, _ := s.Query(ctx, 1, "", "", 0, 0)
-	assert.Equal(t, 2, len(facts))
-
-	// delete
-	_, err = s.Delete(ctx, "none")
-	assert.NotNil(t, err)
-	fact, err = s.Delete(ctx, id)
-	assert.Nil(t, err)
-	assert.Equal(t, id, fact.ID)
-	count, _ = s.Count(ctx, 1, "", "")
-	assert.Equal(t, 1, count)
+	err = s.Create(ctx, "app", "connection", 1, CreateFactRequest{
+		Facts: []fact.FactToIssue{{
+			Key:   "",
+			Value: "test",
+		}},
+	})
+	assert.Error(t, err)
 }

--- a/internal/request/api.go
+++ b/internal/request/api.go
@@ -52,8 +52,6 @@ func (r resource) get(c echo.Context) error {
 // @Accept          json
 // @Produce         json
 // @Security        BearerAuth
-// @Param           page query int false "page number"
-// @Param           per_page query int false "number of elements per page"
 // @Param           app_id   path      string  true  "App id"
 // @Param           connection_id  path string  true  "Connection id"
 // @Param           request body CreateRequest true "query params"

--- a/internal/request/service.go
+++ b/internal/request/service.go
@@ -55,7 +55,7 @@ type CreateRequest struct {
 	Callback    string        `json:"callback"`
 }
 
-// Validate validates the CreateFactRequest fields.
+// Validate validates the CreateRequest fields.
 func (m CreateRequest) Validate() error {
 	return validation.ValidateStruct(&m,
 		validation.Field(&m.Type, validation.Required, validation.Length(0, 128)),


### PR DESCRIPTION
Allows issuing facts to your connections. 

### Usage
In order to issue facts to a connection, you must call this endpoint.

`POST http://localhost:8080/v1/apps/{{app_id}}/connections/{{connection_selfid}}/facts`
```json
{
  "facts": [{
    "key": "flight_number",
    "value": "A1982",
    "source": "Flights",
    "group": {
      "name": "my_group",
      "icon": "flight"
    }
  }]
}
```

This will issue a fact to your connection, that will be stored on your connection's device. Note this won't create a fact on the restful-client database, and you'll need to send a request through the request endpoints to have access to it.