### PR TITLE
Fixes database truncation on tests

### DIFF
--- a/internal/connection/repository_test.go
+++ b/internal/connection/repository_test.go
@@ -16,7 +16,7 @@ import (
 func TestRepository(t *testing.T) {
 	logger, _ := log.NewForTest()
 	db := test.DB(t)
-	test.ResetTables(t, db, "fact", "message")
+	test.ResetTables(t, db, "request", "fact", "message")
 	test.ResetTables(t, db, "connection")
 	repo := NewRepository(db, logger)
 

--- a/internal/fact/service.go
+++ b/internal/fact/service.go
@@ -51,7 +51,7 @@ func (m CreateFactRequest) Validate() error {
 		err := validation.ValidateStruct(&f,
 			validation.Field(&f.Key, validation.Required, validation.Length(0, 128)),
 			validation.Field(&f.Value, validation.Required, validation.Length(0, 128)),
-			// validation.Field(&f.Source, validation.Required, validation.Length(0, 128)),
+			//validation.Field(&f.Source, validation.Required, validation.Length(0, 128)),
 		)
 		if err != nil {
 			return err

--- a/internal/test/db.go
+++ b/internal/test/db.go
@@ -52,16 +52,13 @@ func getEnv(key, fallback string) string {
 func ResetTables(t *testing.T, db *dbcontext.DB, tables ...string) {
 	for _, table := range tables {
 		q := `
-			SET FOREIGN_KEY_CHECKS = 0;
 			DELETE FROM ` + table + `;
-			TRUNCATE TABLE ` + table + `;
-			SET FOREIGN_KEY_CHECKS = 0;`
-		err := db.DB().NewQuery(q).LastError
+			TRUNCATE TABLE ` + table + ` CASCADE;`
+		_, err := db.DB().NewQuery(q).Execute()
 		if err != nil {
 			t.Error(err)
 			t.FailNow()
 		}
-		_, _ = db.DB().TruncateTable(table).Execute()
 	}
 }
 


### PR DESCRIPTION
Table truncation wasn't working well, when you ran the test suite on a second attempt tests were broken because data was not been correctly cleaned up. So this PR addresses this problem.