### PR TITLE
Refresh tokens

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -160,7 +160,7 @@ func buildHandler(logger log.Logger, db *dbcontext.DB, cfg *config.Config) http.
 		authHandler, logger,
 	)
 	auth.RegisterHandlers(rg.Group(""),
-		auth.NewService(cfg.JWTSigningKey, cfg.JWTExpiration, cfg.User, cfg.Password, logger),
+		auth.NewService(cfg, logger),
 		logger,
 	)
 

--- a/config/local.yml.cp
+++ b/config/local.yml.cp
@@ -7,6 +7,8 @@ self_apps:
     self_env: "sandbox" # Self environment you want to point to.
     message_notification_url: "" # The URL to send incoming messages notifications to.
 jwt_signing_key: "" # Signing key for JWT.
+jwt_expiration: 24 # JWT expiration in hours.
+refresh_token_expiration: 128 # JWT refresh expiration in hours.
 user: "demo" # User to be used for JWT authentication.
 password: "pass" # Password to be used for JWT authentication.
 serve_docs: "true" # Serves the docs from the local server on localhost:8080/docs

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v4"
+	"github.com/joinself/restful-client/internal/config"
 	"github.com/joinself/restful-client/internal/entity"
 	"github.com/joinself/restful-client/internal/errors"
 	"github.com/joinself/restful-client/pkg/log"
@@ -14,7 +15,9 @@ import (
 type Service interface {
 	// authenticate authenticates a user using username and password.
 	// It returns a JWT token if authentication succeeds. Otherwise, an error is returned.
-	Login(ctx context.Context, username, password string) (string, error)
+	Login(ctx context.Context, username, password string) (AuthResponse, error)
+
+	Refresh(c context.Context, token string) (AuthResponse, error)
 }
 
 // Identity represents an authenticated user identity.
@@ -26,26 +29,74 @@ type Identity interface {
 }
 
 type service struct {
-	signingKey      string
-	tokenExpiration int
-	user            string
-	password        string
-	logger          log.Logger
+	signingKey       string
+	tokenExpiration  int
+	rTokenExpiration int
+	user             string
+	password         string
+	logger           log.Logger
 }
 
 // NewService creates a new authentication service.
-func NewService(signingKey string, tokenExpiration int, user, password string, logger log.Logger) Service {
-	return service{signingKey, tokenExpiration, user, password, logger}
+func NewService(cfg *config.Config, logger log.Logger) Service {
+	return service{
+		cfg.JWTSigningKey,
+		cfg.JWTExpiration,
+		cfg.RefreshTokenExpiration,
+		cfg.User,
+		cfg.Password,
+		logger}
 }
 
 // Login authenticates a user and generates a JWT token if authentication succeeds.
 // Otherwise, an error is returned.
-func (s service) Login(ctx context.Context, username, password string) (string, error) {
-	if identity := s.authenticate(ctx, username, password); identity != nil {
-		return s.generateJWT(identity)
+func (s service) Login(ctx context.Context, username, password string) (AuthResponse, error) {
+	var res AuthResponse
+	var err error
+	identity := s.authenticate(ctx, username, password)
+	if identity == nil {
+		return res, errors.Unauthorized("")
 	}
 
-	return "", errors.Unauthorized("")
+	res.AccessToken, err = s.generateJWT(identity)
+	if err != nil {
+		return res, err
+	}
+	if s.rTokenExpiration == 0 {
+		return res, nil
+	}
+
+	res.RefreshToken, err = s.generateRefreshJWT(identity)
+	return res, nil
+}
+
+// Refresh authenticates a user based on a refresh_token, if it succeeds it will send back
+// a new access token.
+func (s service) Refresh(ctx context.Context, token string) (AuthResponse, error) {
+	var res AuthResponse
+
+	// Extract the id from the token.
+	id, err := s.getRefreshJWTSubject(token)
+	if err != nil {
+		return res, errors.Unauthorized(err.Error())
+	}
+
+	// Check the user still exists on the DB
+	identity := s.getByID(ctx, id)
+	if identity == nil {
+		return res, errors.Unauthorized("")
+	}
+
+	// Generate an auth token
+	res.AccessToken, err = s.generateJWT(identity)
+	if err != nil {
+		return res, err
+	}
+	if s.rTokenExpiration == 0 {
+		return res, nil
+	}
+
+	return res, nil
 }
 
 // authenticate authenticates a user using username and password.
@@ -63,6 +114,18 @@ func (s service) authenticate(ctx context.Context, username, password string) Id
 	return nil
 }
 
+func (s service) getByID(ctx context.Context, id string) Identity {
+	logger := s.logger.With(ctx, "id", id)
+
+	if id == s.user {
+		logger.Infof("token refresh successful")
+		return entity.User{ID: "100", Name: s.user}
+	}
+
+	logger.Infof("token refresh failed")
+	return nil
+}
+
 // generateJWT generates a JWT that encodes an identity.
 func (s service) generateJWT(identity Identity) (string, error) {
 	// Set custom claims
@@ -70,17 +133,38 @@ func (s service) generateJWT(identity Identity) (string, error) {
 		identity.GetID(),
 		identity.GetName(),
 		jwt.RegisteredClaims{
-			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour * 72)),
+			Subject:   identity.GetID(),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour * time.Duration(s.tokenExpiration))),
 		},
 	}
 
 	// Create token with claims
 	return jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte(s.signingKey))
-	/*
-		return jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
-			"id":   identity.GetID(),
-			"name": identity.GetName(),
-			"exp":  time.Now().Add(time.Duration(s.tokenExpiration) * time.Hour).Unix(),
-		}).SignedString([]byte(s.signingKey))
-	*/
+}
+
+// generateRefreshJWT generates a refresh JWT that encodes an identity.
+func (s service) generateRefreshJWT(identity Identity) (string, error) {
+	// Set custom claims
+	claims := &jwt.RegisteredClaims{
+		Subject:   identity.GetName(),
+		IssuedAt:  jwt.NewNumericDate(time.Now()),
+		ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour * time.Duration(s.rTokenExpiration))),
+	}
+
+	// Create token with claims
+	return jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte(s.signingKey))
+}
+
+func (s service) getRefreshJWTSubject(tokenString string) (string, error) {
+	token, err := jwt.ParseWithClaims(tokenString, &jwt.RegisteredClaims{}, func(token *jwt.Token) (interface{}, error) {
+		return []byte(s.signingKey), nil
+	})
+
+	claims, ok := token.Claims.(*jwt.RegisteredClaims)
+	if !ok || !token.Valid {
+		return "", err
+	}
+
+	return claims.Subject, nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,11 +33,12 @@ type Config struct {
 	// JWT signing key. required.
 	JWTSigningKey string `yaml:"jwt_signing_key" env:"JWT_SIGNING_KEY,secret"`
 	// JWT expiration in hours. Defaults to 72 hours (3 days)
-	JWTExpiration int             `yaml:"jwt_expiration" env:"JWT_EXPIRATION"`
-	SelfApps      []SelfAppConfig `yaml:"self_apps" env:"SELF_APPS"`
-	User          string          `yaml:"user" env:"USER"`
-	Password      string          `yaml:"password" env:"PASSWORD"`
-	ServeDocs     string          `yaml:"serve_docs" env:"SERVE_DOCS"`
+	JWTExpiration          int             `yaml:"jwt_expiration" env:"JWT_EXPIRATION"`
+	RefreshTokenExpiration int             `yaml:"refresh_token_expiration" env:"REFRESH_TOKEN_EXPIRATION"`
+	SelfApps               []SelfAppConfig `yaml:"self_apps" env:"SELF_APPS"`
+	User                   string          `yaml:"user" env:"USER"`
+	Password               string          `yaml:"password" env:"PASSWORD"`
+	ServeDocs              string          `yaml:"serve_docs" env:"SERVE_DOCS"`
 }
 
 // Validate validates the application configuration.


### PR DESCRIPTION
## Context
A *refresh token* is used to generate a new access token. Typically, if the access token has an expiration date, once it expires, the user would have to authenticate again to obtain an access token. With refresh token, this step can be skipped and with a request to the API get a new access token that allows the user to continue accessing the application resources.

Refresh tokens are preferred because credentials authentication should be rate limited (to prevent brute force attacks). Refresh tokens are pretty long and have a high entropy, so brute forcing refresh tokens should be harder.

With this feature restful-client can be configured to return a refresh_token on the authentication process (when configuration value for `refresh_token_expiration` is different than 0), which can be used later to authenticate using the same auth endpoint.

### Authenticating
```
POST /login
{"username":"test","password":"pass"}
```
this will produce a response like 
```
{"token":"xxxxx","refresh_token":"xxxxx"}
```

### Using your access token
You can use the token (access_token) returned on the login call to authenticate all your requests, by using that token as a Bearer on your request headers.

### Refreshing your token
This token is a short living token, that means it will be expiring soon, once expired, you can use your credentials against `/login` endpoint as usual to get a new token, or us the `refresh_token` to get a new access_token. Let's see how to proceed with that second scenario:
```
POST /login
{"refresh_token":"xxxxx"}
```
that again will produce a response like 
```
{"token":"xxxxx"}
```


