### PR TITLE
Change default identifier for messages on api paths

### DIFF
--- a/internal/entity/message.go
+++ b/internal/entity/message.go
@@ -6,7 +6,7 @@ import (
 
 // Message represents a message record.
 type Message struct {
-	ID           int       `json:"id"`
+	ID           int       `json:"-"`
 	ConnectionID int       `json:"-"`
 	ISS          string    `json:"iss"`
 	CID          string    `json:"cid"`

--- a/internal/message/api.go
+++ b/internal/message/api.go
@@ -43,16 +43,11 @@ type resource struct {
 // @Security     BearerAuth
 // @Param        app_id   path      string  true  "App id"
 // @Param        connection_id   path      string  true  "Connection id"
-// @Param        id   path      int  true  "Message id"
+// @Param        jti   path      string  true  "Message JTI"
 // @Success      200  {object}  Message
-// @Router       /apps/{app_id}/connections/{connection_id}/messages/{id} [get]
+// @Router       /apps/{app_id}/connections/{connection_id}/messages/{jti} [get]
 func (r resource) get(c echo.Context) error {
-	id, err := strconv.Atoi(c.Param("id"))
-	if err != nil {
-		return c.JSON(http.StatusBadRequest, err.Error())
-	}
-
-	message, err := r.service.Get(c.Request().Context(), id)
+	message, err := r.service.Get(c.Request().Context(), c.Param("id"))
 	if err != nil {
 		return c.JSON(http.StatusNotFound, err.Error())
 	}
@@ -154,10 +149,10 @@ func (r resource) create(c echo.Context) error {
 // @Security        BearerAuth
 // @Param           app_id   path      string  true  "App id"
 // @Param           connection_id   path      string  true  "Connection id"
-// @Param           message_id   path      int  true  "Message id"
+// @Param           jti   path      string  true  "Message jti"
 // @Param           request body UpdateMessageRequest true "message request"
 // @Success         200  {object}  Message
-// @Router          /apps/{app_id}/connections/{connection_id}/messages/{message_id} [put]
+// @Router          /apps/{app_id}/connections/{connection_id}/messages/{jti} [put]
 func (r resource) update(c echo.Context) error {
 	var input UpdateMessageRequest
 	if err := c.Bind(&input); err != nil {
@@ -165,11 +160,12 @@ func (r resource) update(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, "")
 	}
 
-	id, err := strconv.Atoi(c.Param("id"))
-	if err != nil {
-		return c.JSON(http.StatusInternalServerError, err.Error())
-	}
-	message, err := r.service.Update(c.Request().Context(), c.Param("app_id"), c.Param("connection_id"), id, input)
+	message, err := r.service.Update(
+		c.Request().Context(),
+		c.Param("app_id"),
+		c.Param("connection_id"),
+		c.Param("id"),
+		input)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, err.Error())
 	}
@@ -178,15 +174,10 @@ func (r resource) update(c echo.Context) error {
 }
 
 func (r resource) delete(c echo.Context) error {
-	id, err := strconv.Atoi(c.Param("id"))
-	if err != nil {
-		return c.JSON(http.StatusBadRequest, err.Error())
-	}
-
-	message, err := r.service.Delete(c.Request().Context(), id)
+	err := r.service.Delete(c.Request().Context(), c.Param("id"))
 	if err != nil {
 		return c.JSON(http.StatusNotFound, err.Error())
 	}
 
-	return c.JSON(http.StatusOK, message)
+	return c.JSON(http.StatusOK, "")
 }

--- a/internal/message/api_test.go
+++ b/internal/message/api_test.go
@@ -17,7 +17,7 @@ func TestAPI(t *testing.T) {
 	logger, _ := log.NewForTest()
 	router := test.MockRouter(logger)
 	repo := &mock.MessageRepositoryMock{Items: []entity.Message{
-		{ID: 1, ConnectionID: 123, ISS: "", CID: "", RID: "", Body: "hello!", IAT: time.Now(), CreatedAt: time.Now(), UpdatedAt: time.Now()},
+		{ID: 1, JTI: "1", ConnectionID: 123, ISS: "", CID: "", RID: "", Body: "hello!", IAT: time.Now(), CreatedAt: time.Now(), UpdatedAt: time.Now()},
 	}}
 	connRepo := &mock.ConnectionRepositoryMock{Items: []entity.Connection{
 		{ID: 123, SelfID: "connection", AppID: "app1", Name: "connection123", CreatedAt: time.Now(), UpdatedAt: time.Now()},
@@ -45,7 +45,7 @@ func TestAPI(t *testing.T) {
 		{Name: "update verify", Method: "GET", URL: "/apps/app1/connections/connection/messages/1", Body: "", Header: header, WantStatus: http.StatusOK, WantResponse: `*messagexyz*`},
 		{Name: "update auth error", Method: "PUT", URL: "/apps/app1/connections/connection/messages/1", Body: `{"body":"messagexyz"}`, Header: nil, WantStatus: http.StatusUnauthorized, WantResponse: ""},
 		{Name: "update input error", Method: "PUT", URL: "/apps/app1/connections/connection/messages/1", Body: `"body":"messagexyz"}`, Header: header, WantStatus: http.StatusBadRequest, WantResponse: ""},
-		{Name: "delete ok", Method: "DELETE", URL: "/apps/app1/connections/connection/messages/1", Body: ``, Header: header, WantStatus: http.StatusOK, WantResponse: "*messagexyz*"},
+		{Name: "delete ok", Method: "DELETE", URL: "/apps/app1/connections/connection/messages/1", Body: ``, Header: header, WantStatus: http.StatusOK, WantResponse: ""},
 		{Name: "delete verify", Method: "DELETE", URL: "/apps/app1/connections/connection/messages/1", Body: ``, Header: header, WantStatus: http.StatusNotFound, WantResponse: ""},
 		{Name: "delete auth error", Method: "DELETE", URL: "/apps/app1/connections/connection/messages/1", Body: ``, Header: nil, WantStatus: http.StatusUnauthorized, WantResponse: ""},
 	}

--- a/internal/message/repository_test.go
+++ b/internal/message/repository_test.go
@@ -35,6 +35,7 @@ func TestRepository(t *testing.T) {
 	msg := entity.Message{
 		ConnectionID: connection,
 		Body:         "message1",
+		JTI:          "jti",
 		IAT:          time.Now(),
 		CreatedAt:    time.Now(),
 		UpdatedAt:    time.Now(),
@@ -45,15 +46,16 @@ func TestRepository(t *testing.T) {
 	assert.Equal(t, 1, count2-count)
 
 	// get
-	message, err := repo.Get(ctx, msg.ID)
+	message, err := repo.Get(ctx, msg.JTI)
 	assert.Nil(t, err)
 	assert.Equal(t, "message1", message.Body)
-	_, err = repo.Get(ctx, 0)
+	_, err = repo.Get(ctx, "0")
 	assert.Equal(t, sql.ErrNoRows, err)
 
 	// update
 	err = repo.Update(ctx, entity.Message{
 		ID:           msg.ID,
+		JTI:          msg.JTI,
 		ConnectionID: connection,
 		Body:         "message1 updated",
 		IAT:          time.Now(),
@@ -61,7 +63,7 @@ func TestRepository(t *testing.T) {
 		UpdatedAt:    time.Now(),
 	})
 	assert.Nil(t, err)
-	message, _ = repo.Get(ctx, msg.ID)
+	message, _ = repo.Get(ctx, msg.JTI)
 	assert.Equal(t, "message1 updated", message.Body)
 
 	// query
@@ -70,10 +72,10 @@ func TestRepository(t *testing.T) {
 	assert.Equal(t, count2, len(messages))
 
 	// delete
-	err = repo.Delete(ctx, msg.ID)
+	err = repo.Delete(ctx, msg.JTI)
 	assert.Nil(t, err)
-	_, err = repo.Get(ctx, msg.ID)
+	_, err = repo.Get(ctx, msg.JTI)
 	assert.Equal(t, sql.ErrNoRows, err)
-	err = repo.Delete(ctx, msg.ID)
+	err = repo.Delete(ctx, msg.JTI)
 	assert.Equal(t, sql.ErrNoRows, err)
 }

--- a/internal/message/service_test.go
+++ b/internal/message/service_test.go
@@ -51,7 +51,6 @@ func TestUpdateMessageRequest_Validate(t *testing.T) {
 func Test_service_CRUD(t *testing.T) {
 	logger, _ := log.NewForTest()
 	s := NewService(&mock.MessageRepositoryMock{}, logger, nil)
-
 	ctx := context.Background()
 
 	connection := 1
@@ -85,28 +84,28 @@ func Test_service_CRUD(t *testing.T) {
 	_, _ = s.Create(ctx, "app", "connection", connection, CreateMessageRequest{Body: "test2"})
 
 	// update
-	message, err = s.Update(ctx, "app", "connection", id, UpdateMessageRequest{Body: "test updated"})
+	message, err = s.Update(ctx, "app", "connection", message.JTI, UpdateMessageRequest{Body: "test updated"})
 	assert.Nil(t, err)
 	assert.Equal(t, "test updated", message.Body)
-	_, err = s.Update(ctx, "app", "connection", 1, UpdateMessageRequest{Body: "test updated"})
+	_, err = s.Update(ctx, "app", "connection", "1", UpdateMessageRequest{Body: "test updated"})
 	assert.NotNil(t, err)
 
 	// validation error in update
-	_, err = s.Update(ctx, "app", "connection", id, UpdateMessageRequest{Body: ""})
+	_, err = s.Update(ctx, "app", "connection", message.JTI, UpdateMessageRequest{Body: ""})
 	assert.NotNil(t, err)
 	count, _ = s.Count(ctx)
 	assert.Equal(t, 2, count)
 
 	// unexpected error in update
-	_, err = s.Update(ctx, "app", "connection", id, UpdateMessageRequest{Body: "error"})
+	_, err = s.Update(ctx, "app", "connection", message.JTI, UpdateMessageRequest{Body: "error"})
 	assert.Equal(t, errCRUD, err)
 	count, _ = s.Count(ctx)
 	assert.Equal(t, 2, count)
 
 	// get
-	_, err = s.Get(ctx, 1)
+	_, err = s.Get(ctx, "1")
 	assert.NotNil(t, err)
-	message, err = s.Get(ctx, id)
+	message, err = s.Get(ctx, message.JTI)
 	assert.Nil(t, err)
 	assert.Equal(t, "test updated", message.Body)
 	assert.Equal(t, id, message.ID)
@@ -116,11 +115,10 @@ func Test_service_CRUD(t *testing.T) {
 	assert.Equal(t, 2, len(messages))
 
 	// delete
-	_, err = s.Delete(ctx, 1)
+	err = s.Delete(ctx, "non existing")
 	assert.NotNil(t, err)
-	message, err = s.Delete(ctx, id)
+	err = s.Delete(ctx, message.JTI)
 	assert.Nil(t, err)
-	assert.Equal(t, id, message.ID)
 	count, _ = s.Count(ctx)
 	assert.Equal(t, 1, count)
 }

--- a/internal/self/service.go
+++ b/internal/self/service.go
@@ -138,6 +138,7 @@ func (s *service) processChatMessage(payload map[string]interface{}) error {
 	msg := entity.Message{
 		ConnectionID: c.ID,
 		ISS:          cm.ISS,
+		JTI:          cm.JTI,
 		Body:         cm.Body,
 		IAT:          time.Now(),
 		CreatedAt:    time.Now(),

--- a/migrations/20230803085225_jti_index.down.sql
+++ b/migrations/20230803085225_jti_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX message_jti_idx;

--- a/migrations/20230803085225_jti_index.up.sql
+++ b/migrations/20230803085225_jti_index.up.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX message_jti_idx ON message (jti);

--- a/pkg/mock/message_mock.go
+++ b/pkg/mock/message_mock.go
@@ -3,6 +3,7 @@ package mock
 import (
 	"context"
 	"database/sql"
+	"errors"
 
 	"github.com/joinself/restful-client/internal/entity"
 )
@@ -11,9 +12,9 @@ type MessageRepositoryMock struct {
 	Items []entity.Message
 }
 
-func (m MessageRepositoryMock) Get(ctx context.Context, id int) (entity.Message, error) {
+func (m MessageRepositoryMock) Get(ctx context.Context, id string) (entity.Message, error) {
 	for _, item := range m.Items {
-		if item.ID == id {
+		if item.JTI == id {
 			return item, nil
 		}
 	}
@@ -49,13 +50,13 @@ func (m *MessageRepositoryMock) Update(ctx context.Context, message entity.Messa
 	return nil
 }
 
-func (m *MessageRepositoryMock) Delete(ctx context.Context, id int) error {
+func (m *MessageRepositoryMock) Delete(ctx context.Context, id string) error {
 	for i, item := range m.Items {
-		if item.ID == id {
+		if item.JTI == id {
 			m.Items[i] = m.Items[len(m.Items)-1]
 			m.Items = m.Items[:len(m.Items)-1]
-			break
+			return nil
 		}
 	}
-	return nil
+	return errors.New("not found")
 }


### PR DESCRIPTION
Current implementation is using auto-increment ids for messages to query the api. This pull request will be using message.JTI instead which is also the unique message identifier inside the Self Network.