### PR TITLE
Support out of band requests

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -581,7 +581,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/connection.Connection"
+                            "$ref": "#/definitions/request.Request"
                         }
                     }
                 }
@@ -1067,6 +1067,9 @@ const docTemplate = `{
                 },
                 "updated_at": {
                     "type": "string"
+                },
+                "uri": {
+                    "type": "string"
                 }
             }
         },
@@ -1176,6 +1179,9 @@ const docTemplate = `{
                         "$ref": "#/definitions/request.FactRequest"
                     }
                 },
+                "out_of_band": {
+                    "type": "boolean"
+                },
                 "type": {
                     "type": "string"
                 }
@@ -1204,6 +1210,9 @@ const docTemplate = `{
                 "created_at": {
                     "type": "string"
                 },
+                "deep_link": {
+                    "type": "string"
+                },
                 "facts": {
                     "type": "array",
                     "items": {
@@ -1211,6 +1220,9 @@ const docTemplate = `{
                     }
                 },
                 "id": {
+                    "type": "string"
+                },
+                "qr_code": {
                     "type": "string"
                 },
                 "resources": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -579,7 +579,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/connection.Connection"
+                            "$ref": "#/definitions/request.Request"
                         }
                     }
                 }
@@ -1065,6 +1065,9 @@
                 },
                 "updated_at": {
                     "type": "string"
+                },
+                "uri": {
+                    "type": "string"
                 }
             }
         },
@@ -1174,6 +1177,9 @@
                         "$ref": "#/definitions/request.FactRequest"
                     }
                 },
+                "out_of_band": {
+                    "type": "boolean"
+                },
                 "type": {
                     "type": "string"
                 }
@@ -1202,6 +1208,9 @@
                 "created_at": {
                     "type": "string"
                 },
+                "deep_link": {
+                    "type": "string"
+                },
                 "facts": {
                     "type": "array",
                     "items": {
@@ -1209,6 +1218,9 @@
                     }
                 },
                 "id": {
+                    "type": "string"
+                },
+                "qr_code": {
                     "type": "string"
                 },
                 "resources": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -142,6 +142,8 @@ definitions:
         type: string
       updated_at:
         type: string
+      uri:
+        type: string
     type: object
   fact.response:
     properties:
@@ -212,6 +214,8 @@ definitions:
         items:
           $ref: '#/definitions/request.FactRequest'
         type: array
+      out_of_band:
+        type: boolean
       type:
         type: string
     type: object
@@ -230,11 +234,15 @@ definitions:
         type: boolean
       created_at:
         type: string
+      deep_link:
+        type: string
       facts:
         items:
           $ref: '#/definitions/request.FactRequest'
         type: array
       id:
+        type: string
+      qr_code:
         type: string
       resources:
         items:
@@ -622,7 +630,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/connection.Connection'
+            $ref: '#/definitions/request.Request'
       security:
       - BearerAuth: []
       summary: Sends a request request.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,7 @@ type SelfAppConfig struct {
 	SelfStorageDir      string `yaml:"self_storage_dir"`
 	SelfEnv             string `yaml:"self_env"`
 	CallbackURL         string `yaml:"message_notification_url"`
+	DLCode              string `yaml:"dl_code" env:"DL_CODE"`
 }
 
 // Config represents an application configuration.

--- a/internal/connection/repository_test.go
+++ b/internal/connection/repository_test.go
@@ -16,7 +16,7 @@ import (
 func TestRepository(t *testing.T) {
 	logger, _ := log.NewForTest()
 	db := test.DB(t)
-	test.ResetTables(t, db, "request", "fact", "message")
+	test.ResetTables(t, db, "fact", "request", "message")
 	test.ResetTables(t, db, "connection")
 	repo := NewRepository(db, logger)
 

--- a/internal/entity/fact.go
+++ b/internal/entity/fact.go
@@ -24,10 +24,15 @@ type Fact struct {
 	Fact         string    `json:"fact"`
 	Body         string    `json:"body"`
 	IAT          time.Time `json:"iat"`
+	URL          string    `json:"uri,omitempty" db:"-"`
 	CreatedAt    time.Time `json:"created_at"`
 	UpdatedAt    time.Time `json:"updated_at"`
 }
 
 func (f *Fact) URI(app string) string {
 	return fmt.Sprintf("/v1/apps/%s/connections/%d/facts/%s", app, f.ConnectionID, f.ID)
+}
+
+type Response struct {
+	Facts []Fact `json:"facts"`
 }

--- a/internal/fact/repository_test.go
+++ b/internal/fact/repository_test.go
@@ -15,7 +15,7 @@ import (
 func TestRepository(t *testing.T) {
 	logger, _ := log.NewForTest()
 	db := test.DB(t)
-	test.ResetTables(t, db, "fact", "message", "connection")
+	test.ResetTables(t, db, "attestation", "fact", "message", "connection")
 	repo := NewRepository(db, logger)
 
 	ctx := context.Background()

--- a/internal/request/api.go
+++ b/internal/request/api.go
@@ -55,7 +55,7 @@ func (r resource) get(c echo.Context) error {
 // @Param           app_id   path      string  true  "App id"
 // @Param           connection_id  path string  true  "Connection id"
 // @Param           request body CreateRequest true "query params"
-// @Success         200  {object}  connection.Connection
+// @Success         200  {object}  Request
 // @Router          /apps/{app_id}/connections/{connection_id}/requests [post]
 func (r resource) create(c echo.Context) error {
 	var input CreateRequest

--- a/internal/self/request_service_mock.go
+++ b/internal/self/request_service_mock.go
@@ -1,0 +1,35 @@
+package self
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/joinself/restful-client/internal/entity"
+	"github.com/joinself/restful-client/internal/request"
+	selffact "github.com/joinself/self-go-sdk/fact"
+)
+
+type RequestServiceMock struct {
+	Items []request.Request
+}
+
+func (m RequestServiceMock) Get(ctx context.Context, appID, id string) (request.Request, error) {
+	for _, item := range m.Items {
+		if item.ID == id {
+			return item, nil
+		}
+	}
+	return request.Request{}, sql.ErrNoRows
+}
+
+func (m *RequestServiceMock) Create(ctx context.Context, appID, selfID string, connection int, input request.CreateRequest) (request.Request, error) {
+	r := request.Request{}
+	m.Items = append(m.Items, r)
+	return r, nil
+}
+
+func (m *RequestServiceMock) CreateFactsFromResponse(selfID string, req entity.Request, facts []selffact.Fact) []entity.Fact {
+	r := request.Request{}
+	m.Items = append(m.Items, r)
+	return nil
+}

--- a/pkg/mock/request_repo_mock.go
+++ b/pkg/mock/request_repo_mock.go
@@ -1,0 +1,57 @@
+package mock
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/joinself/restful-client/internal/entity"
+)
+
+type RequestRepositoryMock struct {
+	Items []entity.Request
+}
+
+func (m RequestRepositoryMock) Get(ctx context.Context, id string) (entity.Request, error) {
+	for _, item := range m.Items {
+		if item.ID == id {
+			return item, nil
+		}
+	}
+	return entity.Request{}, sql.ErrNoRows
+}
+
+func (m *RequestRepositoryMock) Create(ctx context.Context, request entity.Request) error {
+	if request.Type == "error" {
+		return ErrCRUD
+	}
+	m.Items = append(m.Items, request)
+	return nil
+}
+
+func (m *RequestRepositoryMock) Update(ctx context.Context, request entity.Request) error {
+	if request.Type == "error" {
+		return ErrCRUD
+	}
+	for i, item := range m.Items {
+		if item.ID == request.ID {
+			m.Items[i] = request
+			break
+		}
+	}
+	return nil
+}
+
+func (m *RequestRepositoryMock) Delete(ctx context.Context, id string) error {
+	for i, item := range m.Items {
+		if item.ID == id {
+			m.Items[i] = m.Items[len(m.Items)-1]
+			m.Items = m.Items[:len(m.Items)-1]
+			break
+		}
+	}
+	return nil
+}
+
+func (m *RequestRepositoryMock) SetStatus(ctx context.Context, id string, status string) error {
+	return nil
+}


### PR DESCRIPTION
## Out of band requests

This pull request introduces out of band requests based on QR code images or Dynamic links. In order to produce an out of band request you can reuse the same request call to `/v1/apps/{{self.appid}}/connections/{{self.connection}}/requests` but adding an optional `out-of-band` boolean to the body of the request like:
```json
{
  "type": "fact",
  "out_of_band": true,
  "facts": [{
    "name": "email_address"
  }]
}
```

The response to this request will include the base64 image and the link so you can add them to your program.
```json
{
  "id": "c1ce1eb8-7711-41c0-ae1f-ac0bf4686fba",
  "typ": "fact",
  "facts": [
    {
      "name": "email_address"
    }
  ],
  "status": "requested",
  "deep_link": "https://....",
  "qr_code": "iVBORw0KGgoAAAANSUhEUgAAAZAAAAGQAQMAAAC6caSPAAAABlBMVEX///8AAABVwtN+AAAJI0lEQVR42uxcQa7zLBIsxIIlNzAXscK1vLBkpCx8LSJfBN+AJQuLGnU7ee/7R7MdiT/6vInykopkU3RXdTcPf6+/199rvCuS9I5XJGvDjCnU5p48ibo9jzL5uiC+zlqXjexjQ2bA++ay6QCZI4snL1vAiu0yZF0wR1amBZgGh8TufVtiB6pr9jL0TW/UcyfP4uti2U2tWGL/VojLsYNAzEAFbJ5QfdqucLIu9nix+vTvgIB7fiDUpsSu3J8kgWVjD2S6mYx/AUSYTGZTILtyRvBw8rbCXQgF1V0wBf6/yP8lkDso7cfrLLUt8zwF7/bncZZal3WeJu/35/G/4tiAEL2aOySkuj3PCAS2o4M+rQhnhUswXfj9j2tESMyBIC9MAc1JzoDbmQPrzeTqm80PQ8rP9rEhVl6YZiCQDbEH3ZUnPe7ExwYrv7Dtx3slvwryKp4AdFcukfoCexZ6JlsAz6fEJs8kH44OQW3bhcDa3CGhpcFegd63LQMeWGXn1o35MQ0O6UbSA18nq2uyKen2hEkWdrUFvjqNLOR+PfB9kGwqJB+WACyz7cHLfj4Jvz9ZDIXXL7K69AlKw0Jgukdz7KF4uEPES3PXbJTIeQJEw/TJY3E/yWJUyCwBRjhriqpJFskOM0KF41ECq7vs6yR35vdSfhPEZniPTTQMGuJRJO+n2ejWPViUBMLk5H428rAQee+afgfbkQNJPi/J/i7Nk6lVuHDSt+WH/ONCivcu2Y7gHSXAav6TNcQaS1DtEsX54F8AYaVLs2hgNrE8wLICwdftiudJn+Sh1LrtYou+DRK7pMPFdl3vbEXDpBXK5DSb4v1+zTDExiNjbMgcKeo5dnF826EaxolqEQt+lEk0dXxJ8N1zLGNDokaYRZ0P2xxZ6r1VWd/Sen9eD3iV1t8HmWEq2mJfkvA3HmJXKSmefk/2PHU/U8y7+80vg0LepYcMNUvHwVIp35V4u9qzgGmNErga4quPDbF9AsXjTSLE8jyJ5aFYnrrAahJPksSx8TLl6yCRKuFyPEXDSNjxbJsk0IoV5hYvMJVJ5c7YkFeHd0lsq9fMCb39DiiTu9egROKPZDEqZJbY0jbmUPQpCK/bKkqzYiPlxYrXqRt/pPWoEKGlv5lHuOOC0DJFEtguCEkTYtbiwmcpvwmiJWjuWrfEgnkKdxWleJ/WOZz0WnAC2xLz6BBM8JLwSe+aeh3J+/I2rfKZ3PcjVN/k18eGCJHpmE0PEOqStTlZSmVyhxdZhskLk/v0dRCrdaMtGxaKHJUc6a67LLHGYig54yXidP/JL6NCYCSGLjYjVJfmeBZJgxe0MnSFs3qS+X73R1FlTIhKa1nCW8N00KWNJcCnVSyPZJBshMmxfx9Ea32uRdUw2kcm9+dlqOmFRZH93ZIsY0NiNpXctWPstEDk2/aktiLXWRTNnrTwklw2g0MAI14HmII8jOMslU02qReIpJDtebwKuDebMTZEywm3tqwuqTK+L2DZtFzU7PUI9A14TF8HkeAJ7pc4IbdnKy6prZZF/EHs8H7n9TC1bm3G4BARWXLfsQStPSOAyR63dpkNq65+93XZfqT1wBCPpj3IyhazKf52N168ThCx9rxMh0+Yf0vQXwOBPBTXbDbCZG3Y3VLm/q5O3YhLqgswOsTmQNmVD92cV9TZmQtBnPh26cOwVzy1lvvJL8NCxL1iO7r2xA9ZUXdXFUTYTEpzrfVhmX8izPdAZtNVpBl5HNsFI0L7KYSGS1YM70ZtfW2/jaFhIQDIFOWGxev1IAF2niCqRX8hWSE0fvv740JMlxvFzeRshckSWeW+r3mC6rGszufD5IEhBXB7NidrW+yhcxfJkqhiecSCW/kQy3Z9Et8XQWTZAZcfouS0YVAlV/Yg1unS1s89dbO3T7IYGVJxT8n491yaa4Cm/3UWCrukLaAFMU9jQ0SP0bX58TMN5cWnmlKr0+peVft2683+dRB5DN41yx7kwd21Ph3VwE1d6qiUxyJ7fmyI1vqc3qAn8yzuNdl7PPuaQxEpkx+T5z33OzREErV89yGxRGuwgCN78GwrpglwT2ajNc3HF0J6ILGotL6LK7g9PJg2dlMhlFAmX7EMDmHXjhVL8ORBbdhpHxn3HOy71octfZg8MKR4ujSLHtOpIBHRsKd8SafnfVJ/QKosGxzSJbnJX2tzx9HVy85TqHVZEbpn2i7J8H/Q8osg8dU9sczK1aZDoy4BQc9/yO/5PcVsNGJ9NMyoEKi0bho82zJHFt+Wezy7wd567LqHUH7a6KNC5rvdKBLT6xysuIU1lkBsTxZT62JlKZnch8nfBLFZDCqPVwfbxisUNKy2hKrO4tZuL0mZLX5kz6gQYSmwRBYRoHoCgrtkB1/dpREr3d3+ZftMm44LeRVUuEMg2LKqaBUvrMtqizwbPc3BPf1GmC+C8K4XdchCW52+kSQpTtceJ7VD/iq62fPgEPtiRdsuIwlfEn8RE6tcoI7DYrGyV7Es+GiYUSFiASr3Q5aQu+xKz7TGs1AWD5NXbQnUrcEMDtGqqxPKhSomVvv779GmjX2CLqVEyz8miL4HMj8m750WakXCzZNObNyzoxcmU70EpX+OnQwLMay1iYkNcCnqIBGsTqEs2zXpCYhDp9QSHoNDxOuwbXpQjHuO53sa6n0CYrofkSSLxb7KF0JMZVtsn8J9EAnvE6nK5DL5KvQWs+Sun9rFqJA+eVnv11nQnGa85pIQuuopUzGxh7ZL9t+J7kEh9nVWPZIpatIdR4Gs4SGOfFlFw2CxfJ169u0zB/tFEG0zOh793eR6d5VPPcyi0SjZC6Zi4/XH4eIhIdDJ14SHjp28a33U+tiyYjLU2dHbvf5xHndISNSSEI+uJxbtNQU9mGP06PasJ7h5PQx9W3615aAQPY0Oxxd14kcSYHNPnexatHDn98tmcXH4SshndpSS9w8tR7g0A3fCN7W6pEdvf8+vDw2RhM+O2lwW24rtLqcvW/6t9XneO3d4CPfLlEC3XzNAR16AHkYsk+ptTFrre5Xvg+A+mNMlGlH/F0HTcjoBe/CebH6IpWWOg0P0dBEAc76HokimVZh8V/6831Pspvqdx5//VmJEyN/r7/X3+v9d/wkAAP//XjKXx79OccIAAAAASUVORK5CYII=",
  "created_at": "0001-01-01T00:00:00Z",
  "updated_at": "0001-01-01T00:00:00Z"
}
```

*Note the deep link field won't be provided if you haven't provided a valid redirection code created on the portal and you've provided it as part of your app configuration under `dl_code` field*

## Compatibility

This pull request breaks compatibility with previous version for fact request based callbacks, it goes from a type `raw` to a type `fact_response` with a body like:
```json
{
	"typ": "fact_response",
	"uri": "",
	"data": {
		"facts": [{
			"id": "57838237-d892-4fc4-b804-cbacece3fc39",
			"request_id": "",
			"iss": "49097555909",
			"status": "accepted",
			"source": "",
			"fact": "email_address",
			"body": "",
			"iat": "0001-01-01T00:00:00Z",
			"uri": "/v1/apps/5f9aed00-eb41-4320-b680-e93622a7c297/connections/30/facts/57838237-d892-4fc4-b804-cbacece3fc39",
			"created_at": "2023-08-17T07:54:22.620574Z",
			"updated_at": "2023-08-17T07:54:22.620574Z"
		}]
	}
}
```