### PR TITLE
Detach requests from connections

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -584,110 +584,6 @@ const docTemplate = `{
                 }
             }
         },
-        "/apps/{app_id}/connections/{connection_id}/requests": {
-            "post": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Sends a request request to the specified self user.",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "requests"
-                ],
-                "summary": "Sends a request request.",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App id",
-                        "name": "app_id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Connection id",
-                        "name": "connection_id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "query params",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/request.CreateRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/request.Request"
-                        }
-                    }
-                }
-            }
-        },
-        "/apps/{app_id}/connections/{connection_id}/requests/{id}": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Get request details by request request id.",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "requests"
-                ],
-                "summary": "Get request details.",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App id",
-                        "name": "app_id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Connection id",
-                        "name": "connection_id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Request request id",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/request.Request"
-                        }
-                    }
-                }
-            }
-        },
         "/apps/{app_id}/connections/{id}": {
             "get": {
                 "security": [
@@ -829,6 +725,96 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/connection.Connection"
+                        }
+                    }
+                }
+            }
+        },
+        "/apps/{app_id}/requests": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Sends a request request to the specified self user.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "requests"
+                ],
+                "summary": "Sends a request request.",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "App id",
+                        "name": "app_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "query params",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/request.CreateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/request.Request"
+                        }
+                    }
+                }
+            }
+        },
+        "/apps/{app_id}/requests/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get request details by request request id.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "requests"
+                ],
+                "summary": "Get request details.",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "App id",
+                        "name": "app_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Request request id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/request.Request"
                         }
                     }
                 }
@@ -1250,6 +1236,9 @@ const docTemplate = `{
                 "callback": {
                     "type": "string"
                 },
+                "connection_self_id": {
+                    "type": "string"
+                },
                 "description": {
                     "type": "string"
                 },
@@ -1346,7 +1335,7 @@ var SwaggerInfo = &swag.Spec{
 	Host:             "localhost:8080",
 	BasePath:         "/v1/",
 	Schemes:          []string{"http,", "https"},
-	Title:            "Echo Swagger Example API",
+	Title:            "Joinself restful-client API",
 	Description:      "This is the api for Joinself restful client.",
 	InfoInstanceName: "swagger",
 	SwaggerTemplate:  docTemplate,

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -6,7 +6,7 @@
     "swagger": "2.0",
     "info": {
         "description": "This is the api for Joinself restful client.",
-        "title": "Echo Swagger Example API",
+        "title": "Joinself restful-client API",
         "termsOfService": "http://swagger.io/terms/",
         "contact": {
             "name": "API Support",
@@ -582,110 +582,6 @@
                 }
             }
         },
-        "/apps/{app_id}/connections/{connection_id}/requests": {
-            "post": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Sends a request request to the specified self user.",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "requests"
-                ],
-                "summary": "Sends a request request.",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App id",
-                        "name": "app_id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Connection id",
-                        "name": "connection_id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "query params",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/request.CreateRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/request.Request"
-                        }
-                    }
-                }
-            }
-        },
-        "/apps/{app_id}/connections/{connection_id}/requests/{id}": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Get request details by request request id.",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "requests"
-                ],
-                "summary": "Get request details.",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App id",
-                        "name": "app_id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Connection id",
-                        "name": "connection_id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Request request id",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/request.Request"
-                        }
-                    }
-                }
-            }
-        },
         "/apps/{app_id}/connections/{id}": {
             "get": {
                 "security": [
@@ -827,6 +723,96 @@
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/connection.Connection"
+                        }
+                    }
+                }
+            }
+        },
+        "/apps/{app_id}/requests": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Sends a request request to the specified self user.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "requests"
+                ],
+                "summary": "Sends a request request.",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "App id",
+                        "name": "app_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "query params",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/request.CreateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/request.Request"
+                        }
+                    }
+                }
+            }
+        },
+        "/apps/{app_id}/requests/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get request details by request request id.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "requests"
+                ],
+                "summary": "Get request details.",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "App id",
+                        "name": "app_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Request request id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/request.Request"
                         }
                     }
                 }
@@ -1246,6 +1232,9 @@
             "type": "object",
             "properties": {
                 "callback": {
+                    "type": "string"
+                },
+                "connection_self_id": {
                     "type": "string"
                 },
                 "description": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -227,6 +227,8 @@ definitions:
     properties:
       callback:
         type: string
+      connection_self_id:
+        type: string
       description:
         type: string
       facts:
@@ -290,7 +292,7 @@ info:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0.html
   termsOfService: http://swagger.io/terms/
-  title: Echo Swagger Example API
+  title: Joinself restful-client API
   version: "1.0"
 paths:
   /apps:
@@ -653,73 +655,6 @@ paths:
       summary: Sends a system notification.
       tags:
       - notifications
-  /apps/{app_id}/connections/{connection_id}/requests:
-    post:
-      consumes:
-      - application/json
-      description: Sends a request request to the specified self user.
-      parameters:
-      - description: App id
-        in: path
-        name: app_id
-        required: true
-        type: string
-      - description: Connection id
-        in: path
-        name: connection_id
-        required: true
-        type: string
-      - description: query params
-        in: body
-        name: request
-        required: true
-        schema:
-          $ref: '#/definitions/request.CreateRequest'
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/request.Request'
-      security:
-      - BearerAuth: []
-      summary: Sends a request request.
-      tags:
-      - requests
-  /apps/{app_id}/connections/{connection_id}/requests/{id}:
-    get:
-      consumes:
-      - application/json
-      description: Get request details by request request id.
-      parameters:
-      - description: App id
-        in: path
-        name: app_id
-        required: true
-        type: string
-      - description: Connection id
-        in: path
-        name: connection_id
-        required: true
-        type: string
-      - description: Request request id
-        in: path
-        name: id
-        required: true
-        type: integer
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/request.Request'
-      security:
-      - BearerAuth: []
-      summary: Get request details.
-      tags:
-      - requests
   /apps/{app_id}/connections/{id}:
     delete:
       consumes:
@@ -815,6 +750,63 @@ paths:
       summary: Updates a connection.
       tags:
       - connections
+  /apps/{app_id}/requests:
+    post:
+      consumes:
+      - application/json
+      description: Sends a request request to the specified self user.
+      parameters:
+      - description: App id
+        in: path
+        name: app_id
+        required: true
+        type: string
+      - description: query params
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/request.CreateRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/request.Request'
+      security:
+      - BearerAuth: []
+      summary: Sends a request request.
+      tags:
+      - requests
+  /apps/{app_id}/requests/{id}:
+    get:
+      consumes:
+      - application/json
+      description: Get request details by request request id.
+      parameters:
+      - description: App id
+        in: path
+        name: app_id
+        required: true
+        type: string
+      - description: Request request id
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/request.Request'
+      security:
+      - BearerAuth: []
+      summary: Get request details.
+      tags:
+      - requests
   /healthcheck:
     get:
       consumes:

--- a/internal/entity/request.go
+++ b/internal/entity/request.go
@@ -17,7 +17,7 @@ type RequestFacts struct {
 type Request struct {
 	ID           string    `json:"id"`
 	Type         string    `json:"typ"`
-	ConnectionID int       `json:"-"`
+	ConnectionID *int      `json:"-"`
 	Facts        []byte    `json:"facts"`
 	Description  string    `json:"description"`
 	Auth         bool      `json:"auth,omitempty"`

--- a/internal/fact/repository.go
+++ b/internal/fact/repository.go
@@ -27,7 +27,7 @@ type Repository interface {
 	// SetStatus updates the fact identified by the given id with the given status.
 	SetStatus(ctx context.Context, id string, status string) error
 	// FindByRequestID returns the fact with the specified request ID.
-	FindByRequestID(ctx context.Context, connectionID int, requestID string) ([]entity.Fact, error)
+	FindByRequestID(ctx context.Context, connectionID *int, requestID string) ([]entity.Fact, error)
 }
 
 // repository persists facts in database
@@ -118,13 +118,15 @@ func (r repository) SetStatus(ctx context.Context, id string, status string) err
 
 var facts []entity.Fact
 
-func (r repository) FindByRequestID(ctx context.Context, connectionID int, requestID string) ([]entity.Fact, error) {
+func (r repository) FindByRequestID(ctx context.Context, connectionID *int, requestID string) ([]entity.Fact, error) {
 
 	sql := r.db.With(ctx).
 		Select().
 		OrderBy("id").
-		Where(&dbx.HashExp{"connection_id": connectionID}).
-		AndWhere(&dbx.HashExp{"request_id": requestID})
+		Where(&dbx.HashExp{"request_id": requestID})
+	if connectionID != nil {
+		sql.AndWhere(&dbx.HashExp{"connection_id": connectionID})
+	}
 
 	err := sql.All(&facts)
 	return facts, err

--- a/internal/request/repository_test.go
+++ b/internal/request/repository_test.go
@@ -28,7 +28,7 @@ func TestRepository(t *testing.T) {
 
 	// create
 	req := entity.Request{
-		ConnectionID: connection,
+		ConnectionID: &connection,
 		CreatedAt:    time.Now(),
 		UpdatedAt:    time.Now(),
 	}
@@ -38,7 +38,7 @@ func TestRepository(t *testing.T) {
 	// get
 	message, err := repo.Get(ctx, req.ID)
 	assert.Nil(t, err)
-	assert.Equal(t, connection, message.ConnectionID)
+	assert.Equal(t, connection, *message.ConnectionID)
 
 	// get unexisting
 	req, err = repo.Get(ctx, "unexisting")

--- a/internal/self/request_service_mock.go
+++ b/internal/self/request_service_mock.go
@@ -22,13 +22,13 @@ func (m RequestServiceMock) Get(ctx context.Context, appID, id string) (request.
 	return request.Request{}, sql.ErrNoRows
 }
 
-func (m *RequestServiceMock) Create(ctx context.Context, appID, selfID string, connection int, input request.CreateRequest) (request.Request, error) {
+func (m *RequestServiceMock) Create(ctx context.Context, appID string, connection *entity.Connection, input request.CreateRequest) (request.Request, error) {
 	r := request.Request{}
 	m.Items = append(m.Items, r)
 	return r, nil
 }
 
-func (m *RequestServiceMock) CreateFactsFromResponse(selfID string, req entity.Request, facts []selffact.Fact) []entity.Fact {
+func (m *RequestServiceMock) CreateFactsFromResponse(conn entity.Connection, req entity.Request, facts []selffact.Fact) []entity.Fact {
 	r := request.Request{}
 	m.Items = append(m.Items, r)
 	return nil

--- a/internal/self/service.go
+++ b/internal/self/service.go
@@ -145,7 +145,7 @@ func (s *service) processFactsQueryResp(body []byte, payload map[string]interfac
 	req, err := s.rRepo.Get(context.Background(), resp.CID)
 	if err != nil {
 		req = entity.Request{
-			ConnectionID: conn.ID,
+			ConnectionID: &conn.ID,
 		}
 	} else {
 		req.Status = resp.Status
@@ -156,7 +156,7 @@ func (s *service) processFactsQueryResp(body []byte, payload map[string]interfac
 			return err
 		}
 	}
-	createdFacts := s.rService.CreateFactsFromResponse(iss, req, facts)
+	createdFacts := s.rService.CreateFactsFromResponse(conn, req, facts)
 	// Return the created facts entity URI.
 	for i, _ := range createdFacts {
 		createdFacts[i].URL = createdFacts[i].URI(s.selfID)

--- a/internal/test/db.go
+++ b/internal/test/db.go
@@ -93,6 +93,6 @@ func CreateRequest(ctx context.Context, db *dbcontext.DB, id string, connectionI
 
 	return db.With(ctx).Model(&entity.Request{
 		ID:           id,
-		ConnectionID: connectionID,
+		ConnectionID: &connectionID,
 	}).Insert()
 }

--- a/migrations/20230818075356_optional_connection_for_requests.down.sql
+++ b/migrations/20230818075356_optional_connection_for_requests.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE request
+ALTER COLUMN connection_id SET NOT NULL;

--- a/migrations/20230818075356_optional_connection_for_requests.up.sql
+++ b/migrations/20230818075356_optional_connection_for_requests.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE request
+ALTER COLUMN connection_id DROP NOT NULL;

--- a/pkg/mock/fact_repo_mock.go
+++ b/pkg/mock/fact_repo_mock.go
@@ -64,6 +64,6 @@ func (m *FactRepositoryMock) SetStatus(ctx context.Context, id string, status st
 	return nil
 }
 
-func (r FactRepositoryMock) FindByRequestID(ctx context.Context, connectionID int, requestID string) ([]entity.Fact, error) {
+func (r FactRepositoryMock) FindByRequestID(ctx context.Context, connectionID *int, requestID string) ([]entity.Fact, error) {
 	return []entity.Fact{}, nil
 }


### PR DESCRIPTION
Because out of band requests can be generated without a specific connection attached to them we need to expose a way to produce those requests without tying it to the connection id.

The current implementation is using a path like `/v1/apps/:app_id/connections/:connection_id/requests/*` and this pull request will be moving all those endpoints to the same level as connections, like `/v1/apps/:app_id/requests/*`.

