### PR TITLE
Fix empty system notifications

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -579,7 +579,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK"
+                        "description": ""
                     }
                 }
             }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -577,7 +577,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK"
+                        "description": ""
                     }
                 }
             }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -649,7 +649,7 @@ paths:
       - application/json
       responses:
         "200":
-          description: OK
+          description: ""
       security:
       - BearerAuth: []
       summary: Sends a system notification.

--- a/internal/notification/api.go
+++ b/internal/notification/api.go
@@ -33,7 +33,7 @@ type resource struct {
 // @Param           app_id   path      string  true  "App id"
 // @Param           connection_id   path      string  true  "Connection id"
 // @Param           request body SystemNotificationData true "system notification"
-// @Success         200
+// @Success         200 ""
 // @Router          /apps/{app_id}/connections/{connection_id}/notify [post]
 func (r resource) create(c echo.Context) error {
 	var input SystemNotificationData

--- a/internal/notification/service.go
+++ b/internal/notification/service.go
@@ -16,15 +16,15 @@ type Service interface {
 
 // SystemNotification
 type SystemNotificationData struct {
-	Notification struct {
+	Notification *struct {
 		Type    string `json:"type"`
 		Title   string `json:"title"`
 		Message string `json:"message"`
-	} `json:"notification"`
-	Metadata struct {
+	} `json:"notification,omitempty"`
+	Metadata *struct {
 		Type    string `json:"type"`
 		Payload string `json:"payload"`
-	} `json:"metadata"`
+	} `json:"metadata,omitempty"`
 }
 
 // Validate validates the SystemNotification fields.


### PR DESCRIPTION
System notifications are sent with a payload like:
```
{
	"notification": {
		"title": "Hello",
		"type": "warning",
		"message": "hello there!"
	}, 
	"metadata": {
		"type": "x",
		"payload": "{}"
	}
}
```

However, both objects, notification and metadata are optional. Even they're not provided golang marshalling is creating empty entries for them, so requests are being sent with empty values for all those fields.

This feature addresses the specified problem