### PR TITLE
Expose response payload

### DIFF
--- a/internal/self/service.go
+++ b/internal/self/service.go
@@ -168,7 +168,9 @@ func (s *service) processFactsQueryResp(body []byte, payload map[string]interfac
 		URI:  "",
 		Data: entity.Response{
 			Facts: createdFacts,
-		}})
+		},
+		Payload: payload,
+	})
 }
 
 func (s *service) processConnectionResp(payload map[string]interface{}) error {

--- a/pkg/webhook/post.go
+++ b/pkg/webhook/post.go
@@ -28,6 +28,8 @@ type WebhookPayload struct {
 	URI string `json:"uri"`
 	// Data the object to be sent.
 	Data interface{} `json:"data"`
+	// Payload the response payload received.
+	Payload map[string]interface{} `json:"payload,omitempty"`
 }
 
 type Poster interface {


### PR DESCRIPTION
When receiving a facts response, we're processing the facts and storing them on the system, however, it's still necessary to access the original payload, this comit exposes that payload.