### PR TITLE
Optional fact request id

### DIFF
--- a/internal/entity/fact.go
+++ b/internal/entity/fact.go
@@ -15,7 +15,7 @@ const (
 type Fact struct {
 	ID           string    `json:"id"`
 	ConnectionID int       `json:"-"`
-	RequestID    string    `json:"request_id"`
+	RequestID    *string   `json:"request_id"`
 	ISS          string    `json:"iss"`
 	CID          string    `json:"cid,omitempty"`
 	JTI          string    `json:"jti,omitempty"`

--- a/internal/fact/repository_test.go
+++ b/internal/fact/repository_test.go
@@ -38,7 +38,7 @@ func TestRepository(t *testing.T) {
 	err = repo.Create(ctx, entity.Fact{
 		ID:           "test1",
 		ConnectionID: connection,
-		RequestID:    request,
+		RequestID:    &request,
 		Body:         "fact1",
 		IAT:          time.Now(),
 		CreatedAt:    time.Now(),
@@ -61,7 +61,7 @@ func TestRepository(t *testing.T) {
 	err = repo.Update(ctx, entity.Fact{
 		ID:           "test1",
 		ConnectionID: connection,
-		RequestID:    request,
+		RequestID:    &request,
 		Body:         "fact1 updated",
 		IAT:          time.Now(),
 		CreatedAt:    time.Now(),

--- a/internal/request/service.go
+++ b/internal/request/service.go
@@ -388,7 +388,6 @@ func (s service) CreateFactsFromResponse(conn entity.Connection, req entity.Requ
 		f := entity.Fact{
 			ID:           id,
 			ConnectionID: conn.ID,
-			RequestID:    req.ID,
 			ISS:          conn.SelfID,
 			Status:       entity.STATUS_ACCEPTED,
 			Fact:         receivedFact.Fact,
@@ -396,6 +395,10 @@ func (s service) CreateFactsFromResponse(conn entity.Connection, req entity.Requ
 			CreatedAt:    now,
 			UpdatedAt:    now,
 		}
+		if len(req.ID) > 0 {
+			f.RequestID = &req.ID
+		}
+
 		err := s.fRepo.Create(context.Background(), f)
 		if err != nil {
 			s.logger.Errorf("failed creating fact: %v", err)

--- a/migrations/20230825074222_optional_request_for_facts.down.sql
+++ b/migrations/20230825074222_optional_request_for_facts.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE fact
+ALTER COLUMN request_id SET NOT NULL;

--- a/migrations/20230825074222_optional_request_for_facts.up.sql
+++ b/migrations/20230825074222_optional_request_for_facts.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE fact
+ALTER COLUMN request_id DROP NOT NULL;


### PR DESCRIPTION
Since facts can be sent to restful client directly without an associated request, the foreign key on facts database is causing those facts to not be persisted on the database.

This comit changes the database request id to be an optional foreign key, so we can store facts without an associated request id.