### PR TITLE
Expose Self urls

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -225,7 +225,12 @@ func setupSelfClients(cfg *config.Config) (map[string]*selfsdk.Client, error) {
 			StorageDir:          c.SelfStorageDir,
 		}
 		if c.SelfEnv != "production" {
-			selfConfig.Environment = c.SelfEnv
+			if c.SelfEnv == "development" {
+				selfConfig.APIURL = c.SelfAPIURL
+				selfConfig.MessagingURL = c.SelfMessagingURL
+			} else {
+				selfConfig.Environment = c.SelfEnv
+			}
 		}
 		client, err := selfsdk.New(selfConfig)
 		if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,8 @@ type SelfAppConfig struct {
 	SelfStorageKey      string `yaml:"self_storage_key"`
 	SelfStorageDir      string `yaml:"self_storage_dir"`
 	SelfEnv             string `yaml:"self_env"`
+	SelfAPIURL          string `yaml:"self_api_url"`
+	SelfMessagingURL    string `yaml:"self_messaging_url"`
 	CallbackURL         string `yaml:"message_notification_url"`
 	DLCode              string `yaml:"dl_code" env:"DL_CODE"`
 }


### PR DESCRIPTION
if you define self_env to development you should be able to also provide self_api_url and self_messaging_url as part of the configuration.