### PR TITLE
Breakdown authentication endpoints

### DIFF
--- a/internal/auth/api.go
+++ b/internal/auth/api.go
@@ -11,6 +11,7 @@ import (
 // RegisterHandlers registers handlers for different HTTP requests.
 func RegisterHandlers(rg *echo.Group, service Service, logger log.Logger) {
 	rg.POST("/login", login(service, logger))
+	rg.POST("/refresh", refresh(service, logger))
 }
 
 // Login godoc
@@ -19,7 +20,7 @@ func RegisterHandlers(rg *echo.Group, service Service, logger log.Logger) {
 // @Tags Authentication
 // @Accept json
 // @Produce json
-// @Param request body LoginRequest true "Authentication request body with your username and password, or a refresh token"
+// @Param request body LoginRequest true "Authentication request body with your username and password"
 // @Success 200 {object} LoginResponse "Successfully authenticated, JWT token and Refresh JWT token are returned in response"
 // @Failure 401,400 {object} response.Error "Returns error details"
 // @Router /login [post]
@@ -40,24 +41,53 @@ func login(service Service, logger log.Logger) echo.HandlerFunc {
 		var resp LoginResponse
 		var ctx = c.Request().Context()
 
-		if req.RefreshToken != "" { // Is a refresh based auth workflow.
-			resp, err = service.Refresh(ctx, req.RefreshToken)
-			if err != nil {
-				return c.JSON(http.StatusUnauthorized, response.Error{
-					Status:  http.StatusUnauthorized,
-					Error:   "You're unauthorized to perform this action",
-					Details: "You've provided a refresh_token, but it's not valid",
-				})
-			}
-		} else { // Is a basic auth workflow.
-			resp, err = service.Login(ctx, req.Username, req.Password)
-			if err != nil {
-				return c.JSON(http.StatusUnauthorized, response.Error{
-					Status:  http.StatusUnauthorized,
-					Error:   "You're unauthorized to perform this action",
-					Details: "Provided auth credentials are invalid",
-				})
-			}
+		resp, err = service.Login(ctx, req.Username, req.Password)
+		if err != nil {
+			return c.JSON(http.StatusUnauthorized, response.Error{
+				Status:  http.StatusUnauthorized,
+				Error:   "You're unauthorized to perform this action",
+				Details: "Provided auth credentials are invalid",
+			})
+		}
+
+		return c.JSON(http.StatusOK, resp)
+	}
+}
+
+// Refresh godoc
+// @Summary Refresh JWT token
+// @Description Takes a refresh token and returns a new JWT token for API interaction.
+// @Tags Authentication
+// @Accept json
+// @Produce json
+// @Param request body RefreshRequest true "Request body with your refresh token"
+// @Success 200 {object} LoginResponse "Successfully refreshed, new JWT token is returned in response"
+// @Failure 401,400 {object} response.Error "Returns error details"
+// @Router /refresh [post]
+func refresh(service Service, logger log.Logger) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		var req RefreshRequest
+
+		if err := c.Bind(&req); err != nil {
+			logger.With(c.Request().Context()).Errorf("invalid request: %v", err)
+			return c.JSON(response.DefaultBadRequestError())
+		}
+
+		if reqErr := req.Validate(); reqErr != nil {
+			return c.JSON(reqErr.Status, reqErr)
+		}
+
+		var err error
+		var resp LoginResponse
+		var ctx = c.Request().Context()
+
+		resp, err = service.Refresh(ctx, req.RefreshToken)
+		if err != nil {
+			return c.JSON(http.StatusUnauthorized, response.Error{
+				Status:  http.StatusUnauthorized,
+				Error:   "You're unauthorized to perform this action",
+				Details: "You've provided a refresh_token, but it's not valid",
+			})
 		}
 
 		return c.JSON(http.StatusOK, resp)

--- a/internal/auth/api_test.go
+++ b/internal/auth/api_test.go
@@ -73,19 +73,50 @@ func TestLoginAPIEndpoint(t *testing.T) {
 			WantStatus:   http.StatusBadRequest,
 			WantResponse: "",
 		},
+	}
+	for _, tc := range tests {
+		test.Endpoint(t, router, tc)
+	}
+}
+
+func TestRefreshAPIEndpoint(t *testing.T) {
+	logger, _ := log.NewForTest()
+	router := test.MockRouter(logger)
+
+	RegisterHandlers(router.Group(""), mockService{}, logger)
+
+	tests := []test.APITestCase{
 		{
-			Name:         "refresh token",
+			Name:         "success",
 			Method:       "POST",
-			URL:          "/login",
+			URL:          "/refresh",
 			Body:         `{"refresh_token":"test_token_test_token_test_token_test_token_test_token_"}`,
 			Header:       nil,
 			WantStatus:   http.StatusOK,
 			WantResponse: `{"token":"token-100","refresh_token":"r-token-100"}`,
 		},
 		{
+			Name:         "bad json",
+			Method:       "POST",
+			URL:          "/refresh",
+			Body:         `{]`,
+			Header:       nil,
+			WantStatus:   http.StatusBadRequest,
+			WantResponse: "",
+		},
+		{
+			Name:         "invalid data",
+			Method:       "POST",
+			URL:          "/refresh",
+			Body:         `{"refresh_token":""}`,
+			Header:       nil,
+			WantStatus:   http.StatusBadRequest,
+			WantResponse: "",
+		},
+		{
 			Name:         "refresh token errored",
 			Method:       "POST",
-			URL:          "/login",
+			URL:          "/refresh",
 			Body:         `{"refresh_token":"test_token_test_token_test_token_test_token_test_token_error"}`,
 			Header:       nil,
 			WantStatus:   http.StatusUnauthorized,

--- a/internal/auth/support.go
+++ b/internal/auth/support.go
@@ -9,9 +9,8 @@ import (
 
 // LoginRequest authentication login input request.
 type LoginRequest struct {
-	Username     string `json:"username"`
-	Password     string `json:"password"`
-	RefreshToken string `json:"refresh_token"`
+	Username string `json:"username"`
+	Password string `json:"password"`
 }
 
 // Validate validates the LoginRequest struct
@@ -21,16 +20,11 @@ func (r *LoginRequest) Validate() *response.Error {
 		validation.Field(&r.Password, validation.Required, validation.Length(5, 128)),
 	)
 
-	errRefresh := validation.ValidateStruct(r,
-		validation.Field(&r.RefreshToken, validation.Required, validation.Length(32, 255)),
-	)
-
-	// If both validations have failed, return an error.
-	if errBasic != nil && errRefresh != nil {
+	if errBasic != nil {
 		return &response.Error{
 			Status:  http.StatusBadRequest,
 			Error:   "Invalid input",
-			Details: "You must provide user and password, or a refresh_token",
+			Details: "You must provide user and password",
 		}
 	}
 
@@ -41,4 +35,26 @@ func (r *LoginRequest) Validate() *response.Error {
 type LoginResponse struct {
 	AccessToken  string `json:"token"`
 	RefreshToken string `json:"refresh_token,omitempty"`
+}
+
+// RefreshRequest refresh your JWT token.
+type RefreshRequest struct {
+	RefreshToken string `json:"refresh_token"`
+}
+
+// Validate validates the LoginRequest struct
+func (r *RefreshRequest) Validate() *response.Error {
+	errRefresh := validation.ValidateStruct(r,
+		validation.Field(&r.RefreshToken, validation.Required, validation.Length(32, 255)),
+	)
+
+	if errRefresh != nil {
+		return &response.Error{
+			Status:  http.StatusBadRequest,
+			Error:   "Invalid input",
+			Details: "You must provide a refresh_token",
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
This pull request introduces significant changes to the authentication system.

Separation of login and token refresh process: Previously, the same endpoint (/login) was used for both user login and token refreshing. With this PR, the login process is solely responsible for authenticating the user and issuing tokens, while a new endpoint (/refresh) is introduced specifically for refreshing JWT tokens. This separation of concerns improves the clarity and maintainability of the code.

Changes in LoginRequest struct: The LoginRequest struct no longer includes the RefreshToken field. This is in line with the above point, where the login process is detached from the token refreshing process.

Addition of RefreshRequest struct: A new struct RefreshRequest is added to handle refresh token requests. It includes the RefreshToken field and a new validation method to check the validity of the refresh token.

Update of tests: Changes are made to the test files api_test.go to reflect the changes in the endpoints. New tests are added to test the newly introduced /refresh endpoint and its functionalities.

These changes improve the modularity and readability of the code, and make it easier to maintain and extend in the future