### PR TITLE
Add ACL check in API and update comment in service

### DIFF
--- a/internal/app/api.go
+++ b/internal/app/api.go
@@ -3,6 +3,7 @@ package app
 import (
 	"net/http"
 
+	"github.com/joinself/restful-client/pkg/acl"
 	"github.com/joinself/restful-client/pkg/log"
 	"github.com/joinself/restful-client/pkg/pagination"
 	"github.com/joinself/restful-client/pkg/response"
@@ -88,8 +89,13 @@ func (r resource) create(c echo.Context) error {
 // @Param           id   path      int  true  "ID of the app to delete"
 // @Success         204  {string} string  "No Content"
 // @Failure         404 {object} response.Error "Not found - The requested resource does not exist, or you don't have permissions to access it"
-// @Router          /apps/{id} [delete]
+// @Router          /apps/{app_id} [delete]
 func (r resource) delete(c echo.Context) error {
+	user := acl.CurrentUser(c)
+	if user == nil || !user.IsAdmin() {
+		return c.JSON(response.DefaultNotFoundError())
+	}
+
 	if _, err := r.service.Delete(c.Request().Context(), c.Param("id")); err != nil {
 		return c.JSON(response.DefaultNotFoundError())
 	}

--- a/internal/app/service.go
+++ b/internal/app/service.go
@@ -109,7 +109,7 @@ func (s service) Delete(ctx context.Context, id string) (App, error) {
 		return App{}, err
 	}
 
-	// Start the runner.
+	// Stop the runner.
 	s.runner.Stop(id)
 
 	if err = s.repo.Delete(ctx, app.ID); err != nil {


### PR DESCRIPTION
This PR introduces the following changes:

1. In `api.go`, the Access Control List (ACL) functionality is now imported from the `github.com/joinself/restful-client/pkg/acl` package.
2. In the `delete` function of `api.go`, an ACL check is now performed to ensure that the user is an admin. If the user is not an admin, a default 'Not Found' error is returned.
3. The route parameter for the delete API has been renamed from `{id}` to `{app_id}` for clarity.
4. In `service.go`, a comment above the `s.runner.Stop(id)` line has been corrected from `// Start the runner.` to `// Stop the runner.` to accurately reflect the function's action.

These changes enhance the security of the delete API by ensuring only admin users can perform delete operations while improving the readability and accuracy of the code comments.
