### PR TITLE
process incoming metrics

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
           sudo cp /tmp/golangci-lint-1.21.0-linux-amd64/golangci-lint /usr/local/bin
           make lint
           make build
-          make migrate
+          make migrate-test
           make test
       - name: Failure notification
         if: ${{ github.ref == 'refs/heads/main' && failure() }}

--- a/Makefile
+++ b/Makefile
@@ -105,13 +105,13 @@ migrate-reset: ## reset database and re-run all migrations
 	@$(MIGRATE) up
 
 .PHONY: migrate-test
-migrate: ## run all new database migrations
+migrate-test: ## run all new database migrations
 	@echo "Running all new database migrations..."
 	@echo " -> $(MIGRATE_TEST) up"
 	@$(MIGRATE_TEST) up
 
 .PHONY: migrate-test-reset
-migrate-reset: ## reset database and re-run all migrations
+migrate-test-reset: ## reset database and re-run all migrations
 	@echo "Resetting test database..."
 	@$(MIGRATE_TEST) drop
 	@echo "Running all test database migrations..."

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/joinself/restful-client/internal/fact"
 	"github.com/joinself/restful-client/internal/healthcheck"
 	"github.com/joinself/restful-client/internal/message"
+	"github.com/joinself/restful-client/internal/metric"
 	"github.com/joinself/restful-client/internal/notification"
 	"github.com/joinself/restful-client/internal/request"
 	"github.com/joinself/restful-client/internal/self"
@@ -128,6 +129,7 @@ func buildHandler(logger log.Logger, db *dbcontext.DB, cfg *config.Config) http.
 	accountRepo := account.NewRepository(db, logger)
 	appRepo := app.NewRepository(db, logger)
 	apikeyRepo := apikey.NewRepository(db, tokenChecker, logger)
+	metricRepo := metric.NewRepository(db, tokenChecker, logger)
 
 	// Services
 	rService := request.NewService(requestRepo, factRepo, attestationRepo, logger)
@@ -138,6 +140,7 @@ func buildHandler(logger log.Logger, db *dbcontext.DB, cfg *config.Config) http.
 		RequestRepo:    requestRepo,
 		RequestService: rService,
 		AppRepo:        appRepo,
+		MetricRepo:     metricRepo,
 		Logger:         logger,
 		StorageKey:     cfg.StorageKey,
 		StorageDir:     cfg.StorageDir,
@@ -184,6 +187,10 @@ func buildHandler(logger log.Logger, db *dbcontext.DB, cfg *config.Config) http.
 	)
 	apikey.RegisterHandlers(appsGroup,
 		apikey.NewService(cfg, apikeyRepo, logger),
+		logger,
+	)
+	metric.RegisterHandlers(appsGroup,
+		metric.NewService(cfg, metricRepo, logger),
 		logger,
 	)
 

--- a/internal/apikey/support.go
+++ b/internal/apikey/support.go
@@ -39,7 +39,7 @@ func (m CreateApiKeyRequest) Validate() *response.Error {
 	err := validation.ValidateStruct(&m,
 		validation.Field(&m.Name, validation.Required, validation.Length(0, 128)),
 		validation.Field(&m.Scope, validation.Required, validation.Length(0, 128)),
-		validation.Field(&m.Scope, validation.In("FULL", "MESSAGING", "REQUESTS")),
+		validation.Field(&m.Scope, validation.In("FULL", "MESSAGING", "REQUESTS", "METRICS")),
 	)
 	if err == nil {
 		return nil
@@ -62,6 +62,9 @@ func (m CreateApiKeyRequest) GetResources(appID string) []string {
 		},
 		"REQUESTS": []string{
 			fmt.Sprintf("GET /v1/apps/%s/requests*", appID),
+		},
+		"METRICS": []string{
+			fmt.Sprintf("GET /v1/apps/%s/metrics*", appID),
 		},
 	}
 

--- a/internal/entity/metric.go
+++ b/internal/entity/metric.go
@@ -1,0 +1,13 @@
+package entity
+
+import "time"
+
+type Metric struct {
+	ID        int       `json:"id"`
+	AppID     string    `json:"appid" db:"appid"`
+	UUID      int       `json:"uuid"`
+	Recipient string    `json:"recipient"`
+	Actions   string    `json:"actions"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}

--- a/internal/metric/api.go
+++ b/internal/metric/api.go
@@ -1,0 +1,85 @@
+package metric
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/joinself/restful-client/pkg/log"
+	"github.com/joinself/restful-client/pkg/pagination"
+	"github.com/joinself/restful-client/pkg/response"
+	"github.com/labstack/echo/v4"
+)
+
+// RegisterHandlers sets up the routing of the HTTP handlers.
+func RegisterHandlers(r *echo.Group, service Service, logger log.Logger) {
+	res := resource{service, logger}
+
+	r.GET("/:app_id/metrics", res.query)
+}
+
+type resource struct {
+	service Service
+	logger  log.Logger
+}
+
+// ListMetrics godoc
+// @Summary        Retrieve a paginated list of metrics
+// @Description    Retrieves a paginated list of metrics for a specific app_id, matching the specified filters.
+//
+//	Pagination is provided through optional page and per_page parameters.
+//	If not provided, the defaults are page 1 and per_page 10.
+//
+// @Tags           metrics
+// @Accept         json
+// @Produce        json
+// @Security       BearerAuth
+// @Param          app_id   path   string  true  "Unique Identifier (UUID) for the App"
+// @Param          page query int false "The page number for pagination. If not provided, the default is 1."
+// @Param          per_page query int false "The number of metrics to return per page for pagination. If not provided, the default is 10."
+// @Success        200  {object}  ExtListResponse  "Successful retrieval of metrics list will return a 200 status and a list of metrics"
+// @Failure        500  {object}  response.Error "In case of an internal server error during the request, a 500 status and an error object will be returned"
+// @Router         /apps/{app_id}/metrics [get]
+func (r resource) query(c echo.Context) error {
+	ctx := c.Request().Context()
+	var from, to int64
+	from = 0
+	to = time.Now().Unix()
+
+	if v, err := strconv.Atoi(c.QueryParam("from")); err == nil {
+		from = int64(v)
+	}
+	if v, err := strconv.Atoi(c.QueryParam("to")); err == nil {
+		to = int64(v)
+	}
+
+	count, err := r.service.Count(ctx, c.Param("app_id"), from, to)
+	if err != nil {
+		return c.JSON(response.DefaultInternalError(c, r.logger, err.Error()))
+	}
+
+	pages := pagination.NewFromRequest(c.Request(), count)
+	metrics, err := r.service.Query(ctx,
+		c.Param("app_id"),
+		pages.Offset(),
+		pages.Limit(),
+		from,
+		to,
+	)
+	if err != nil {
+		return c.JSON(response.DefaultInternalError(c, r.logger, err.Error()))
+	}
+
+	mms := []ExtMetric{}
+	for _, m := range metrics {
+		mms = append(mms, ExtMetric{
+			ID:        m.UUID,
+			Recipient: m.Recipient,
+			Actions:   m.Actions,
+			CreatedAt: m.CreatedAt,
+		})
+	}
+
+	pages.Items = mms
+	return c.JSON(http.StatusOK, pages)
+}

--- a/internal/metric/repository.go
+++ b/internal/metric/repository.go
@@ -1,0 +1,98 @@
+package metric
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	dbx "github.com/go-ozzo/ozzo-dbx"
+	"github.com/joinself/restful-client/internal/entity"
+	"github.com/joinself/restful-client/pkg/dbcontext"
+	"github.com/joinself/restful-client/pkg/filter"
+	"github.com/joinself/restful-client/pkg/log"
+)
+
+// Repository encapsulates the logic to access metrics from the data source.
+type Repository interface {
+	// Count returns the number of metrics.
+	Count(ctx context.Context, appID string, from, to int64) (int, error)
+	// Query returns the list of metrics with the given offset and limit.
+	Query(ctx context.Context, appid string, offset, limit int, from, to int64) ([]entity.Metric, error)
+	// Upsert creates or updates an metric entry based on its uuid.
+	Upsert(ctx context.Context, metric *entity.Metric) error
+}
+
+// repository persists metrics in database
+type repository struct {
+	db      *dbcontext.DB
+	checker *filter.Checker
+	logger  log.Logger
+}
+
+// NewRepository creates a new metric repository
+func NewRepository(db *dbcontext.DB, checker *filter.Checker, logger log.Logger) Repository {
+	return repository{db, checker, logger}
+}
+
+// Create saves a new metric record in the database.
+// It returns the ID of the newly inserted metric record.
+func (r repository) create(ctx context.Context, metric *entity.Metric) error {
+	return r.db.With(ctx).Model(metric).Insert()
+}
+
+// Update saves the changes to an metric in the database.
+func (r repository) update(ctx context.Context, metric entity.Metric) error {
+	return r.db.With(ctx).Model(&metric).Update()
+}
+
+// Upsert creates or updates an metric entry based on its uuid.
+func (r repository) Upsert(ctx context.Context, metric *entity.Metric) error {
+	m, err := r.getByUUID(ctx, metric.AppID, metric.UUID)
+	if err != nil {
+		return r.create(ctx, metric)
+	}
+	metric.ID = m.ID
+	return r.update(ctx, *metric)
+}
+
+// Count returns the number of the metric records in the database.
+func (r repository) Count(ctx context.Context, appID string, from, to int64) (int, error) {
+	var count int
+	err := r.db.With(ctx).Select("COUNT(*)").
+		From("metric").
+		Where(&dbx.HashExp{"appid": appID}).
+		AndWhere(dbx.Between("created_at", time.Unix(from, 0), time.Unix(to, 0))).
+		Row(&count)
+	return count, err
+}
+
+// Query retrieves the metric records with the specified offset and limit from the database.
+func (r repository) Query(ctx context.Context, appid string, offset, limit int, from, to int64) ([]entity.Metric, error) {
+	var metrics []entity.Metric
+	err := r.db.With(ctx).
+		Select().
+		Where(&dbx.HashExp{"appid": appid}).
+		AndWhere(dbx.Between("created_at", time.Unix(from, 0), time.Unix(to, 0))).
+		OrderBy("id").
+		Offset(int64(offset)).
+		OrderBy("created_at DESC").
+		Limit(int64(limit)).
+		All(&metrics)
+	return metrics, err
+}
+
+func (r repository) getByUUID(ctx context.Context, appID string, id int) (entity.Metric, error) {
+	var metrics []entity.Metric
+
+	err := r.db.With(ctx).
+		Select().
+		OrderBy("id").
+		Where(&dbx.HashExp{"uuid": id, "appid": appID}).
+		All(&metrics)
+
+	if len(metrics) == 0 {
+		return entity.Metric{}, errors.New("sql: no rows in result set")
+	}
+
+	return metrics[0], err
+}

--- a/internal/metric/service.go
+++ b/internal/metric/service.go
@@ -1,0 +1,55 @@
+package metric
+
+import (
+	"context"
+
+	"github.com/joinself/restful-client/internal/config"
+	"github.com/joinself/restful-client/internal/entity"
+	"github.com/joinself/restful-client/pkg/log"
+	"github.com/joinself/self-go-sdk/fact"
+)
+
+// Service encapsulates usecase logic for metrics.
+type Service interface {
+	Query(ctx context.Context, appid string, offset, limit int, from, to int64) ([]Metric, error)
+	Count(ctx context.Context, appid string, from, to int64) (int, error)
+}
+
+// FactService service to manage sending and receiving fact requests
+type FactService interface {
+	Request(*fact.FactRequest) (*fact.FactResponse, error)
+}
+
+// Metric represents the data about an metric.
+type Metric struct {
+	entity.Metric
+}
+
+type service struct {
+	repo       Repository
+	signingKey string
+	logger     log.Logger
+}
+
+// NewService creates a new metric service.
+func NewService(cfg *config.Config, repo Repository, logger log.Logger) Service {
+	return service{repo, cfg.JWTSigningKey, logger}
+}
+
+// Count returns the number of metrics.
+func (s service) Count(ctx context.Context, appid string, from, to int64) (int, error) {
+	return s.repo.Count(ctx, appid, from, to)
+}
+
+// Query returns the metrics with the specified offset and limit.
+func (s service) Query(ctx context.Context, appid string, offset, limit int, from, to int64) ([]Metric, error) {
+	items, err := s.repo.Query(ctx, appid, offset, limit, from, to)
+	if err != nil {
+		return nil, err
+	}
+	result := []Metric{}
+	for _, item := range items {
+		result = append(result, Metric{item})
+	}
+	return result, nil
+}

--- a/internal/metric/support.go
+++ b/internal/metric/support.go
@@ -1,0 +1,10 @@
+package metric
+
+import "time"
+
+type ExtMetric struct {
+	ID        int       `json:"id"`
+	Recipient string    `json:"recipient"`
+	Actions   string    `json:"actions"`
+	CreatedAt time.Time `json:"created_at"`
+}

--- a/internal/self/runner.go
+++ b/internal/self/runner.go
@@ -7,6 +7,7 @@ import (
 	"github.com/joinself/restful-client/internal/entity"
 	"github.com/joinself/restful-client/internal/fact"
 	"github.com/joinself/restful-client/internal/message"
+	"github.com/joinself/restful-client/internal/metric"
 	"github.com/joinself/restful-client/internal/request"
 	"github.com/joinself/restful-client/pkg/log"
 	"github.com/joinself/restful-client/pkg/support"
@@ -32,6 +33,7 @@ type runner struct {
 	mRepo      message.Repository
 	rRepo      request.Repository
 	aRepo      appStatusSetter
+	metRepo    metric.Repository
 	logger     log.Logger
 	rService   request.Service
 	storageKey string
@@ -44,6 +46,7 @@ type RunnerConfig struct {
 	MessageRepo    message.Repository
 	RequestRepo    request.Repository
 	AppRepo        appStatusSetter
+	MetricRepo     metric.Repository
 	Logger         log.Logger
 	RequestService request.Service
 	StorageKey     string
@@ -58,6 +61,7 @@ func NewRunner(config RunnerConfig) Runner {
 		mRepo:      config.MessageRepo,
 		rRepo:      config.RequestRepo,
 		aRepo:      config.AppRepo,
+		metRepo:    config.MetricRepo,
 		logger:     config.Logger,
 		rService:   config.RequestService,
 		storageKey: config.StorageKey,
@@ -94,6 +98,7 @@ func (r *runner) Run(app entity.App) error {
 		RequestRepo:    r.rRepo,
 		Logger:         r.logger,
 		RequestService: r.rService,
+		MetricRepo:     r.metRepo,
 		SelfClient:     support.NewSelfClient(client),
 		Poster:         webhook.NewWebhook(app.Callback),
 	})

--- a/internal/self/support.go
+++ b/internal/self/support.go
@@ -1,0 +1,68 @@
+package self
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"time"
+
+	"github.com/joinself/restful-client/internal/entity"
+)
+
+type metrc struct {
+	UUID      int      `json:"uuid"`
+	Recipient string   `json:"recipient"`
+	Actions   []string `json:"actions"`
+	Date      int64    `json:"date`
+}
+
+type attestedFacts struct {
+	Transactions []metrc
+}
+
+type transactionFact struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+type transactionFacts struct {
+	Facts []transactionFact `json:"facts"`
+}
+
+func parseIncomingMetrics(payload map[string]interface{}) ([]*entity.Metric, error) {
+	metrics := []*entity.Metric{}
+	for _, a := range payload["attestations"].([]interface{}) {
+		p1 := a.(map[string]interface{})["payload"].(string)
+		p, err := base64.RawURLEncoding.DecodeString(p1)
+		if err != nil {
+			return metrics, err
+		}
+
+		var x transactionFacts
+		err = json.Unmarshal(p, &x)
+		if err != nil {
+			return metrics, err
+		}
+		for _, f := range x.Facts {
+			var af attestedFacts
+			err := json.Unmarshal([]byte(f.Value), &af)
+			if err != nil {
+				return metrics, err
+			}
+			for _, t := range af.Transactions {
+				// Check if metric entry already exist...
+				a, err := json.Marshal(t.Actions)
+				if err != nil {
+					return metrics, err
+				}
+				metrics = append(metrics, &entity.Metric{
+					UUID:      t.UUID,
+					Recipient: t.Recipient,
+					Actions:   string(a),
+					CreatedAt: time.Unix(t.Date, 0),
+				})
+			}
+
+		}
+	}
+	return metrics, nil
+}

--- a/migrations/20240308092428_create_metrics.down.sql
+++ b/migrations/20240308092428_create_metrics.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE metric;

--- a/migrations/20240308092428_create_metrics.up.sql
+++ b/migrations/20240308092428_create_metrics.up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE metric
+(
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    appid               VARCHAR NOT NULL,
+    uuid                INTEGER NOT NULL,
+    recipient           VARCHAR NOT NULL,
+    actions             VARCHAR NOT NULL,
+    created_at          TIMESTAMP NOT NULL,
+    updated_at          TIMESTAMP NOT NULL,
+    UNIQUE(uuid)
+);


### PR DESCRIPTION
chore(Makefile): rename 'migrate' target to 'migrate-test' for clarity and consistency
feat(server/main.go): add metric repository to the buildHandler function to support metric-related functionality
feat(apikey/support.go): add 'METRICS' as a valid value for the 'Scope' field in CreateApiKeyRequest struct
feat(entity/metric.go): add Metric entity struct to represent a metric record in the database
feat(metric/api.go): add RegisterHandlers function to set up routing for metric-related API endpoints
feat(metric/repository.go): add metric repository implementation to interact with the metric table in the database

feat(metric): add metric service and repository to handle metrics data
feat(metric): add support for querying metrics and counting metrics
feat(metric): add Metric struct to represent metric data
feat(metric): add support for requesting and receiving facts in FactService interface
feat(metric): add support for sending and receiving fact requests in FactService interface
feat(metric): add support for managing metric data in service struct
feat(metric): add NewService function to create a new metric service
feat(metric): implement Count method to count the number of metrics
feat(metric): implement Query method to query metrics with specified offset and limit
feat(metric): add support for external metrics in ExtMetric struct
feat(metric): add support for parsing incoming metrics in parseIncomingMetrics function
feat(metric): add support for parsing attested facts in parseIncomingMetrics function
feat(metric): add support for parsing transaction facts in parseIncomingMetrics function
feat(metric): add support for parsing transaction actions in parseIncomingMetrics function
feat(metric): add support for parsing transaction date in parseIncomingMetrics function
feat(metric): add support for creating metric entries in parseIncomingMetrics function
feat(metric): add migration files for creating metric table