### PR TITLE
Update account password change flow

### DIFF
--- a/internal/account/api.go
+++ b/internal/account/api.go
@@ -60,7 +60,7 @@ func (r resource) create(c echo.Context) error {
 	return c.JSON(http.StatusCreated, CreateAccountResponse{
 		UserName:               account.UserName,
 		Resources:              account.Resources,
-		RequiresPasswordChange: account.RequiresPasswordChange,
+		RequiresPasswordChange: (account.RequiresPasswordChange == 1),
 	})
 }
 

--- a/internal/account/api_test.go
+++ b/internal/account/api_test.go
@@ -37,7 +37,7 @@ func (m mockService) Create(ctx context.Context, input CreateAccountRequest) (Ac
 		entity.Account{
 			UserName:               input.Username,
 			Resources:              strings.Join(input.Resources, ","),
-			RequiresPasswordChange: 0,
+			RequiresPasswordChange: 1,
 		},
 	}, nil
 }
@@ -80,7 +80,7 @@ func TestCreateAccountAPIEndpointAsAdmin(t *testing.T) {
 			Body:         `{"username":"test_larger","password":"pass_larger","resources":[]}`,
 			Header:       nil,
 			WantStatus:   http.StatusCreated,
-			WantResponse: `{"requires_password_change":0, "resources":"", "user_name":"test_larger"}`,
+			WantResponse: `{"requires_password_change":true, "resources":"", "user_name":"test_larger"}`,
 		},
 		{
 			Name:         "invalid input",
@@ -270,7 +270,7 @@ func OTestChangePasswordAPIEndpointAsAdmin(t *testing.T) {
 			Body:         `{"new_password":"new_password","password":"pass_larger","resources":[]}`,
 			Header:       nil,
 			WantStatus:   http.StatusCreated,
-			WantResponse: `{"requires_password_change":0, "resources":"", "user_name":"test_larger"}`,
+			WantResponse: `{"requires_password_change":false, "resources":"", "user_name":"test_larger"}`,
 		},
 		{
 			Name:         "invalid input",

--- a/internal/account/repository.go
+++ b/internal/account/repository.go
@@ -91,7 +91,6 @@ func (r repository) Create(ctx context.Context, account entity.Account) error {
 	}
 	account.Salt = string(salt)
 	account.HashedPassword = r.hashPassword(account.Password, []byte(account.Salt))
-	account.RequiresPasswordChange = 1
 
 	return r.db.With(ctx).Model(&account).Insert()
 }

--- a/internal/account/repository_test.go
+++ b/internal/account/repository_test.go
@@ -44,7 +44,7 @@ func TestRepository(t *testing.T) {
 	// get
 	account, err := repo.Get(ctx, username, password)
 	assert.Nil(t, err)
-	assert.Equal(t, 1, account.RequiresPasswordChange)
+	assert.Equal(t, 0, account.RequiresPasswordChange)
 
 	// get unexisting
 	_, err = repo.Get(ctx, "unexisting", "test0")

--- a/internal/account/service.go
+++ b/internal/account/service.go
@@ -58,11 +58,19 @@ func (s service) Create(ctx context.Context, req CreateAccountRequest) (Account,
 
 	now := time.Now()
 	account := entity.Account{
-		UserName:  req.Username,
-		Password:  req.Password,
-		CreatedAt: now,
-		UpdatedAt: now,
+		UserName:               req.Username,
+		Password:               req.Password,
+		CreatedAt:              now,
+		UpdatedAt:              now,
+		RequiresPasswordChange: 1,
 	}
+
+	if req.RequiresPasswordChange != nil {
+		if *req.RequiresPasswordChange == false {
+			account.RequiresPasswordChange = 0
+		}
+	}
+
 	account.SetResources(req.Resources)
 	err = s.repo.Create(ctx, account)
 	if err != nil {

--- a/internal/account/service_test.go
+++ b/internal/account/service_test.go
@@ -69,6 +69,7 @@ func Test_service_CRUD(t *testing.T) {
 	})
 	assert.Nil(t, err)
 	assert.Equal(t, username, account.UserName)
+	assert.Equal(t, account.RequiresPasswordChange, 1)
 	assert.NotEmpty(t, account.CreatedAt)
 	assert.NotEmpty(t, account.UpdatedAt)
 	count, _ = s.Count(ctx)
@@ -91,4 +92,20 @@ func Test_service_CRUD(t *testing.T) {
 	assert.Nil(t, err)
 	count, _ = s.Count(ctx)
 	assert.Equal(t, 0, count)
+
+	// successful creation without password change
+	username2 := "selfid2"
+	f := false
+	account2, err := s.Create(ctx, CreateAccountRequest{
+		Username:               username2,
+		Password:               "password",
+		Resources:              []string{"appid"},
+		RequiresPasswordChange: &f,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, username2, account2.UserName)
+	assert.Equal(t, account2.RequiresPasswordChange, 0)
+	assert.NotEmpty(t, account2.CreatedAt)
+	assert.NotEmpty(t, account2.UpdatedAt)
+
 }

--- a/internal/account/support.go
+++ b/internal/account/support.go
@@ -9,9 +9,10 @@ import (
 
 // CreateAccountRequest represents an account creation request.
 type CreateAccountRequest struct {
-	Username  string   `json:"username"`
-	Password  string   `json:"password"`
-	Resources []string `json:"resources"`
+	Username               string   `json:"username"`
+	Password               string   `json:"password"`
+	Resources              []string `json:"resources"`
+	RequiresPasswordChange *bool    `json:"requires_password_change,omitempty"`
 }
 
 // Validate validates the CreateAccountRequest fields.
@@ -36,7 +37,7 @@ func (m CreateAccountRequest) Validate() *response.Error {
 type CreateAccountResponse struct {
 	UserName               string `json:"user_name"`
 	Resources              string `json:"resources"`
-	RequiresPasswordChange int    `json:"requires_password_change"`
+	RequiresPasswordChange bool   `json:"requires_password_change"`
 }
 
 // ChangePasswordRequest represents an account update request.


### PR DESCRIPTION
This commit includes  updates to the account creation workflow by allowing the client to predefine the `requires_password_change` it as false, preventing the user from having to change its password on its first interactions.

Note  this still defaults to `true`, so it's mandatory to provide `requires_password_change=false` if you want to skip this step.